### PR TITLE
Feature/view answer report

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/data/model/Report.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/data/model/Report.kt
@@ -1,0 +1,42 @@
+package com.android.sample.data.model
+
+//This file's goal is to define the data structures used in the app. This is a preliminary version that we will probably modify in the soon future so we can better fit the app's needs.
+// We are keeping it simple for now, but we will likely need to add more fields and relations later.
+
+// Represents the possible statuses for a veterinary report.
+// ESCALATED is intentionally handled separately by the UI (dedicated button).
+enum class ReportStatus {
+    PENDING,
+    IN_PROGRESS,
+    RESOLVED,
+    ESCALATED
+}
+
+// Represents the type of user currently using the app.
+// Used to adapt the UI (farmer vs. vet behavior).
+enum class UserRole {
+    FARMER,
+    VET,
+    AUTHORITY
+}
+
+// Simple location data structure, same as is the Bootcamp
+data class Location(
+    val latitude: Double,
+    val longitude: Double,
+    val name: String? = null
+)
+
+// Main data class describing a veterinary report.
+// Some fields will be resolved from IDs later (e.g., farmerName from farmerId).
+data class Report(
+    val id: String,
+    val title: String,
+    val description: String,
+    val photoUri: String?, // For now, unused (will show placeholder)
+    val farmerId: String,
+    val vetId: String?,
+    val status: ReportStatus,
+    val answer: String?,
+    val location: Location?
+)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/report/ReportViewScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/report/ReportViewScreen.kt
@@ -1,0 +1,244 @@
+package com.android.sample.ui.report
+
+// Preview imports
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.android.sample.data.model.*
+
+/**
+ * Displays the detailed view of a single report. The UI dynamically adapts depending on the current
+ * user's role (Farmer or Vet).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReportViewScreen(navController: NavController, userRole: UserRole, viewModel: ReportViewModel) {
+  val report by viewModel.report
+  val answerText by viewModel.answerText
+  val selectedStatus by viewModel.status
+  val context = LocalContext.current
+
+  var isEscalateDialogOpen by remember { mutableStateOf(false) }
+
+  // ---- Helper: Color based on status ----
+  @Composable
+  fun statusColor(status: ReportStatus): Color {
+    return when (status) {
+      ReportStatus.PENDING -> MaterialTheme.colorScheme.surfaceVariant
+      ReportStatus.IN_PROGRESS -> MaterialTheme.colorScheme.tertiaryContainer
+      ReportStatus.RESOLVED -> MaterialTheme.colorScheme.secondaryContainer
+      ReportStatus.ESCALATED -> MaterialTheme.colorScheme.error
+    }
+  }
+
+  Scaffold(
+      topBar = {
+        // Top bar with back arrow and title/status
+        TopAppBar(
+            title = {
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceBetween,
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = report.title,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f))
+                    Box(
+                        modifier =
+                            Modifier.background(
+                                    color = statusColor(selectedStatus),
+                                    shape = MaterialTheme.shapes.small)
+                                .padding(horizontal = 12.dp, vertical = 6.dp)) {
+                          Text(
+                              text = selectedStatus.name.replace("_", " "),
+                              style = MaterialTheme.typography.labelLarge,
+                              color = MaterialTheme.colorScheme.onSurface)
+                        }
+                  }
+            },
+            navigationIcon = {
+              IconButton(onClick = { navController.popBackStack() }) {
+                Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+              }
+            })
+      }) { padding ->
+
+        // Main scrollable content
+        Column(
+            modifier =
+                Modifier.padding(padding)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)) {
+
+              // ---- Farmer or Vet info line ----
+              Text(
+                  text =
+                      if (userRole == UserRole.VET) "Farmer ID: ${report.farmerId}"
+                      else "Vet ID: ${report.vetId ?: "Unassigned"}",
+                  style = MaterialTheme.typography.bodyMedium,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+              // ---- Photo ---- For now, I am skipping this part since I had trouble loading a
+              // placeholder image
+              /*Image(
+                  imageVector = Icons.Filled.Image,
+                  contentDescription = "Report photo",
+                  modifier = Modifier
+                      .fillMaxWidth()
+                      .height(200.dp)
+                      .background(MaterialTheme.colorScheme.surfaceVariant)
+              )*/
+
+              // ---- Description ----
+              Text(text = report.description, style = MaterialTheme.typography.bodyLarge)
+
+              // ---- Answer section ----
+              Text(
+                  text = "Answer:",
+                  style = MaterialTheme.typography.titleMedium,
+                  fontWeight = FontWeight.SemiBold)
+
+              if (userRole == UserRole.FARMER) {
+                // Farmer: read-only answer
+                Text(
+                    text = report.answer ?: "No answer yet.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+              } else if (userRole == UserRole.VET) {
+                // Vet: editable TextField
+                OutlinedTextField(
+                    value = answerText,
+                    onValueChange = { viewModel.onAnswerChange(it) },
+                    placeholder = { Text("Write your answer here...") },
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 100.dp))
+              }
+
+              // ---- Status dropdown (Vet only) ----
+              if (userRole == UserRole.VET) {
+                var expanded by remember { mutableStateOf(false) }
+                ExposedDropdownMenuBox(
+                    expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+                      OutlinedTextField(
+                          value = selectedStatus.name.replace("_", " "),
+                          onValueChange = {},
+                          label = { Text("Status") },
+                          readOnly = true,
+                          trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                          },
+                          modifier = Modifier.menuAnchor())
+                      ExposedDropdownMenu(
+                          expanded = expanded, onDismissRequest = { expanded = false }) {
+                            listOf(
+                                    ReportStatus.PENDING,
+                                    ReportStatus.IN_PROGRESS,
+                                    ReportStatus.RESOLVED)
+                                .forEach { status ->
+                                  DropdownMenuItem(
+                                      text = { Text(status.name.replace("_", " ")) },
+                                      onClick = {
+                                        viewModel.onStatusChange(status)
+                                        expanded = false
+                                      })
+                                }
+                          }
+                    }
+              }
+
+              // ---- Escalate button (Vet only) ----
+              if (userRole == UserRole.VET && selectedStatus != ReportStatus.ESCALATED) {
+                Button(
+                    onClick = { isEscalateDialogOpen = true },
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error),
+                    modifier = Modifier.fillMaxWidth()) {
+                      Text("Escalate to Authorities")
+                    }
+              }
+
+              // ---- Escalation confirmation dialog ----
+              if (isEscalateDialogOpen) {
+                AlertDialog(
+                    onDismissRequest = { isEscalateDialogOpen = false },
+                    title = { Text("Confirm Escalation") },
+                    text = {
+                      Text("Are you sure you want to escalate this report to the authorities?")
+                    },
+                    confirmButton = {
+                      TextButton(
+                          onClick = {
+                            viewModel.onEscalate()
+                            isEscalateDialogOpen = false
+                          }) {
+                            Text("Yes")
+                          }
+                    },
+                    dismissButton = {
+                      TextButton(onClick = { isEscalateDialogOpen = false }) { Text("Cancel") }
+                    })
+              }
+
+              // ---- Bottom row: Map + Save ----
+              Row(
+                  modifier = Modifier.fillMaxWidth(),
+                  horizontalArrangement = Arrangement.SpaceBetween) {
+                    OutlinedButton(
+                        onClick = {
+                          Toast.makeText(context, "Map not implemented yet", Toast.LENGTH_SHORT)
+                              .show()
+                        }) {
+                          Text("View on Map")
+                        }
+
+                    Button(onClick = { viewModel.onSave() }) { Text("Save") }
+                  }
+            }
+      }
+}
+
+/**
+ * Preview of the ReportViewScreen for both farmer and vet roles. Allows testing of layout and
+ * colors directly in Android Studio.
+ */
+@Preview(showBackground = true, name = "Farmer View")
+@Composable
+fun PreviewReportViewFarmer() {
+  MaterialTheme {
+    val navController = rememberNavController()
+    val viewModel = ReportViewModel()
+    ReportViewScreen(
+        navController = navController, userRole = UserRole.FARMER, viewModel = viewModel)
+  }
+}
+
+@Preview(showBackground = true, name = "Vet View")
+@Composable
+fun PreviewReportViewVet() {
+  MaterialTheme {
+    val navController = rememberNavController()
+    val viewModel = ReportViewModel()
+    ReportViewScreen(navController = navController, userRole = UserRole.VET, viewModel = viewModel)
+  }
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/report/ReportsViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/report/ReportsViewModel.kt
@@ -1,56 +1,55 @@
 package com.android.sample.ui.report
 
-import androidx.lifecycle.ViewModel
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.State
-import com.example.agrihealthalert.model.*
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import com.android.sample.data.model.*
 
 /**
- * ViewModel holding the state of a report being viewed.
- * Currently uses mock data and local state only.
+ * ViewModel holding the state of a report being viewed. Currently uses mock data and local state
+ * only.
  */
 class ReportViewModel : ViewModel() {
 
-    // ---- Mock report for testing ----
-    private val _report = mutableStateOf(
-        Report(
-            id = "RPT001",
-            title = "My sheep is acting strange",
-            description = "Since this morning, my sheep keeps getting on its front knees.",
-            photoUri = null, // Placeholder for now
-            farmerId = "FARMER_123",
-            vetId = "VET_456",
-            status = ReportStatus.PENDING,
-            answer = null,
-            location = Location(46.5191, 6.5668, "Lausanne Farm")
-        )
-    )
+  // ---- Mock report for testing ----
+  private val _report =
+      mutableStateOf(
+          Report(
+              id = "RPT001",
+              title = "My sheep is acting strange",
+              description = "Since this morning, my sheep keeps getting on its front knees.",
+              photoUri = null, // Placeholder for now
+              farmerId = "FARMER_123",
+              vetId = "VET_456",
+              status = ReportStatus.PENDING,
+              answer = null,
+              location = Location(46.5191, 6.5668, "Lausanne Farm")))
 
-    // Expose immutable version of report
-    val report: State<Report> = _report
+  // Expose immutable version of report
+  val report: State<Report> = _report
 
-    // ---- Local mutable state for vet actions ----
-    private val _answerText = mutableStateOf(_report.value.answer ?: "")
-    val answerText: State<String> = _answerText
+  // ---- Local mutable state for vet actions ----
+  private val _answerText = mutableStateOf(_report.value.answer ?: "")
+  val answerText: State<String> = _answerText
 
-    private val _status = mutableStateOf(_report.value.status)
-    val status: State<ReportStatus> = _status
+  private val _status = mutableStateOf(_report.value.status)
+  val status: State<ReportStatus> = _status
 
-    // ---- Update functions ----
-    fun onAnswerChange(newText: String) {
-        _answerText.value = newText
-    }
+  // ---- Update functions ----
+  fun onAnswerChange(newText: String) {
+    _answerText.value = newText
+  }
 
-    fun onStatusChange(newStatus: ReportStatus) {
-        _status.value = newStatus
-    }
+  fun onStatusChange(newStatus: ReportStatus) {
+    _status.value = newStatus
+  }
 
-    fun onEscalate() {
-        _status.value = ReportStatus.ESCALATED
-    }
+  fun onEscalate() {
+    _status.value = ReportStatus.ESCALATED
+  }
 
-    // Save logic will be implemented later (Firebase, etc.)
-    fun onSave() {
-        // For now, do nothing
-    }
+  // Save logic will be implemented later (Firebase, etc.)
+  fun onSave() {
+    // For now, do nothing
+  }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/report/ReportsViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/report/ReportsViewModel.kt
@@ -1,0 +1,56 @@
+package com.android.sample.ui.report
+
+import androidx.lifecycle.ViewModel
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.State
+import com.example.agrihealthalert.model.*
+
+/**
+ * ViewModel holding the state of a report being viewed.
+ * Currently uses mock data and local state only.
+ */
+class ReportViewModel : ViewModel() {
+
+    // ---- Mock report for testing ----
+    private val _report = mutableStateOf(
+        Report(
+            id = "RPT001",
+            title = "My sheep is acting strange",
+            description = "Since this morning, my sheep keeps getting on its front knees.",
+            photoUri = null, // Placeholder for now
+            farmerId = "FARMER_123",
+            vetId = "VET_456",
+            status = ReportStatus.PENDING,
+            answer = null,
+            location = Location(46.5191, 6.5668, "Lausanne Farm")
+        )
+    )
+
+    // Expose immutable version of report
+    val report: State<Report> = _report
+
+    // ---- Local mutable state for vet actions ----
+    private val _answerText = mutableStateOf(_report.value.answer ?: "")
+    val answerText: State<String> = _answerText
+
+    private val _status = mutableStateOf(_report.value.status)
+    val status: State<ReportStatus> = _status
+
+    // ---- Update functions ----
+    fun onAnswerChange(newText: String) {
+        _answerText.value = newText
+    }
+
+    fun onStatusChange(newStatus: ReportStatus) {
+        _status.value = newStatus
+    }
+
+    fun onEscalate() {
+        _status.value = ReportStatus.ESCALATED
+    }
+
+    // Save logic will be implemented later (Firebase, etc.)
+    fun onSave() {
+        // For now, do nothing
+    }
+}


### PR DESCRIPTION
# Summary

This PR introduces the initial implementation of the report visualization feature in the app, including data models, ViewModel, and the detailed report screen.

## Changes Included

1. **Data Models** (`Report`, `Location`, `ReportStatus`, `UserRole`)  
   - Preliminary structures for veterinary reports.  
   - Shared schema intended for ViewModels, repositories, and UI layers.  

2. **ViewModel** (`ReportViewModel`)  
   - Manages state for a single report (report details, vet answer, status).  
   - Local state only; persistence and repository integration will be added later

3. **UI** (`ReportViewScreen` composable)  
   - Role-aware UI for farmers and vets (editable fields, status dropdown, escalation dialog, placeholder map, and save actions).  
   - Includes preview composables for both user roles.  

## Notes

- The **navigation import line in `build.gradle.kts`** is currently missing. This should be handled in the Navigation part of the project I think, so I haven’t implemented it.  
- I **haven’t tested** the implementation yet, but I wanted feedback to confirm if the structure and handling regarding **authentication and repository interaction** seems correct.  
- **AI assistance** was used to help plan the skeleton of the feature and fix compilation errors.
