### PR TITLE
Feature/basic navigation

### DIFF
--- a/AgriHealth-Alert-main/app/build.gradle.kts
+++ b/AgriHealth-Alert-main/app/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(platform(libs.compose.bom))
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     globalTestImplementation(libs.androidx.junit)
     globalTestImplementation(libs.androidx.espresso.core)

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/sample/screen/navigation/NavigationSprint1Test.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/sample/screen/navigation/NavigationSprint1Test.kt
@@ -1,0 +1,92 @@
+package com.android.sample.screen.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.android.sample.AgriHealthApp
+import com.android.sample.ui.authentification.SignInScreenTestTags
+import com.android.sample.ui.farmer.OverviewScreenTestTags
+import com.android.sample.ui.navigation.NavigationTestTags
+import com.android.sample.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * First implementation of navigation tests. Doesn't cover all auth and assumes that the first
+ * screen of AgrihealthApp is Overview.
+ */
+class NavigationSprint1Test {
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Before
+  fun setUp() {
+    // Set the content to the Overview screen before each test
+    composeTestRule.setContent { AgriHealthApp() }
+    composeTestRule
+        .onNodeWithTag(NavigationTestTags.TOP_BAR_TITLE)
+        .assertIsDisplayed()
+        .assertTextContains(Screen.Overview.name)
+  }
+
+  @Test
+  fun overviewScreen_displaysCorrectTitle() {
+    // Assert that the title of the top bar is "Overview"
+    composeTestRule
+        .onNodeWithTag(NavigationTestTags.TOP_BAR_TITLE)
+        .assertIsDisplayed()
+        .assertTextContains(Screen.Overview.name)
+  }
+
+  @Test
+  fun overviewScreen_displaysBottomBar() {
+    // Assert that the bottom navigation bar is displayed
+    composeTestRule.onNodeWithTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
+  }
+
+  @Test
+  fun overviewScreen_navigateToMap() {
+    // Click on the Map tab in the bottom navigation bar
+    composeTestRule.onNodeWithTag(NavigationTestTags.MAP_TAB).performClick()
+    // Assert that the Map screen is displayed
+    composeTestRule
+        .onNodeWithTag(NavigationTestTags.TOP_BAR_TITLE)
+        .assertIsDisplayed()
+        .assertTextContains(Screen.Map.name)
+  }
+
+  @Test
+  fun overviewScreen_navigateToAddReport() {
+    // Click on the "Add Report" button
+    composeTestRule.onNodeWithTag(OverviewScreenTestTags.ADD_REPORT_BUTTON).performClick()
+    // Assert that the Add Report screen is displayed
+    composeTestRule
+        .onNodeWithTag(NavigationTestTags.TOP_BAR_TITLE)
+        .assertIsDisplayed()
+        .assertTextContains(Screen.AddReport.name)
+  }
+
+  @Test
+  fun overviewScreen_navigateToAuth() {
+    // Click on the "Sign Out" button
+    composeTestRule.onNodeWithTag(OverviewScreenTestTags.LOGOUT_BUTTON).performClick()
+    // Assert that the Auth screen is displayed
+    composeTestRule.onNodeWithTag(SignInScreenTestTags.SIGN_IN_BUTTON).assertIsDisplayed()
+  }
+
+  @Test
+  fun addReportScreen_goBackToOverview() {
+    // Navigate to the Add Report screen
+    composeTestRule.onNodeWithTag(OverviewScreenTestTags.ADD_REPORT_BUTTON).performClick()
+    // Click on the "Go Back" button
+    composeTestRule.onNodeWithTag(NavigationTestTags.GO_BACK_BUTTON).performClick()
+    // Assert that the Overview screen is displayed
+    composeTestRule
+        .onNodeWithTag(NavigationTestTags.TOP_BAR_TITLE)
+        .assertIsDisplayed()
+        .assertTextContains(Screen.Overview.name)
+  }
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/MainActivity.kt
@@ -12,7 +12,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import androidx.navigation.compose.rememberNavController
 import com.android.sample.resources.C
+import com.android.sample.ui.authentification.SignInScreen
+import com.android.sample.ui.farmer.AddReportScreen
+import com.android.sample.ui.farmer.MapScreen
+import com.android.sample.ui.farmer.OverviewScreen
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.Screen
 import com.android.sample.ui.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {
@@ -24,9 +34,57 @@ class MainActivity : ComponentActivity() {
         Surface(
             modifier = Modifier.fillMaxSize().semantics { testTag = C.Tag.main_screen_container },
             color = MaterialTheme.colorScheme.background) {
-              Greeting("Android")
+              AgriHealthApp()
             }
       }
+    }
+  }
+}
+
+@Composable
+fun AgriHealthApp() {
+  val navController = rememberNavController()
+  val navigationActions = NavigationActions(navController)
+  val startDestination =
+      // TODO replace by real authentication check
+      if (true
+      // needs to be replaced with the condition of a user being already signed in
+      ) Screen.Auth.name
+      else Screen.Overview.route
+
+  NavHost(navController = navController, startDestination = startDestination) {
+    navigation(
+        startDestination = Screen.Auth.route,
+        route = Screen.Auth.name,
+    ) {
+      composable(Screen.Auth.route) {
+        SignInScreen(onSignedIn = { navigationActions.navigateTo(Screen.Overview) })
+      }
+    }
+
+    navigation(
+        startDestination = Screen.Overview.route,
+        route = Screen.Overview.name,
+    ) {
+      composable(Screen.Overview.route) {
+        OverviewScreen(
+            onAddReport = { navigationActions.navigateTo(Screen.AddReport) },
+            onSignedOut = { navigationActions.navigateTo(Screen.Auth) },
+            navigationActions = navigationActions,
+        )
+      }
+      composable(Screen.AddReport.route) {
+        AddReportScreen(
+            onDone = { navigationActions.navigateTo(Screen.Overview) },
+            onGoBack = { navigationActions.goBack() })
+      }
+    }
+
+    navigation(
+        startDestination = Screen.Map.route,
+        route = Screen.Map.name,
+    ) {
+      composable(Screen.Map.route) { MapScreen(navigationActions) }
     }
   }
 }
@@ -38,6 +96,6 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
-  SampleAppTheme { Greeting("Android") }
+fun AgriHealthPreview() {
+  SampleAppTheme { AgriHealthApp() }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/MainActivity.kt
@@ -47,7 +47,7 @@ fun AgriHealthApp() {
   val navigationActions = NavigationActions(navController)
   val startDestination =
       // TODO replace by real authentication check
-      if (true
+      if (false
       // needs to be replaced with the condition of a user being already signed in
       ) Screen.Auth.name
       else Screen.Overview.route

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/authentification/SignInScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/authentification/SignInScreen.kt
@@ -1,0 +1,28 @@
+package com.android.sample.ui.authentification
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SignInScreen(
+    onSignedIn: () -> Unit,
+) {
+    Scaffold(
+        content = { padding ->
+            Button(onClick = onSignedIn, modifier = Modifier.padding(padding)) {
+                Text(text = "Sign In")
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun SignInScreenPreview() {
+    SignInScreen(onSignedIn = {})
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/authentification/SignInScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/authentification/SignInScreen.kt
@@ -8,6 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 
+object SignInScreenTestTags {
+  const val SIGN_IN_BUTTON = "signInButton"
+}
+
 @Composable
 fun SignInScreen(
     onSignedIn: () -> Unit,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/authentification/SignInScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/authentification/SignInScreen.kt
@@ -12,17 +12,16 @@ import androidx.compose.ui.tooling.preview.Preview
 fun SignInScreen(
     onSignedIn: () -> Unit,
 ) {
-    Scaffold(
-        content = { padding ->
-            Button(onClick = onSignedIn, modifier = Modifier.padding(padding)) {
-                Text(text = "Sign In")
-            }
+  Scaffold(
+      content = { padding ->
+        Button(onClick = onSignedIn, modifier = Modifier.padding(padding)) {
+          Text(text = "Sign In")
         }
-    )
+      })
 }
 
 @Preview
 @Composable
 fun SignInScreenPreview() {
-    SignInScreen(onSignedIn = {})
+  SignInScreen(onSignedIn = {})
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/AddReportScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/AddReportScreen.kt
@@ -1,12 +1,24 @@
 package com.android.sample.ui.farmer
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Preview
 @Composable
-fun AddReportScreen() {
-    // Implementation of the Add Report Screen
+fun AddReportScreen(
+    onDone: () -> Unit = {},
+    onGoBack: () -> Unit = {},
+) {
+  // Implementation of the Add Report Screen
+
+  Column {
     Text(text = "Add Report Screen")
+    Button(onClick = onDone, modifier = Modifier.padding(8.dp)) { Text(text = "Done") }
+  }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/AddReportScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/AddReportScreen.kt
@@ -1,0 +1,12 @@
+package com.android.sample.ui.farmer
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun AddReportScreen() {
+    // Implementation of the Add Report Screen
+    Text(text = "Add Report Screen")
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/MapScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/MapScreen.kt
@@ -1,0 +1,10 @@
+package com.android.sample.ui.farmer
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun MapScreen() {
+    // Implementation of the Map Screen
+    Text(text= "Map Screen")
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/MapScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/MapScreen.kt
@@ -24,7 +24,5 @@ fun MapScreen(
             onTabSelected = { tab -> navigationActions?.navigateTo(tab.destination) },
             modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU))
       },
-      content = { pd ->
-        Column { Text(text = "Map Screen", modifier = Modifier.padding(pd)) }
-      })
+      content = { pd -> Column { Text(text = "Map Screen", modifier = Modifier.padding(pd)) } })
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/MapScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/MapScreen.kt
@@ -1,10 +1,30 @@
 package com.android.sample.ui.farmer
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.sample.ui.navigation.BottomNavigationMenu
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.NavigationTestTags
+import com.android.sample.ui.navigation.Tab
 
 @Composable
-fun MapScreen() {
-    // Implementation of the Map Screen
-    Text(text= "Map Screen")
+fun MapScreen(
+    navigationActions: NavigationActions? = null,
+) {
+  // Temp Implementation of the Map Screen
+  Scaffold(
+      bottomBar = {
+        BottomNavigationMenu(
+            selectedTab = Tab.Map,
+            onTabSelected = { tab -> navigationActions?.navigateTo(tab.destination) },
+            modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU))
+      },
+      content = { pd ->
+        Column { Text(text = "Map Screen", modifier = Modifier.padding(pd)) }
+      })
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/OverviewScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/OverviewScreen.kt
@@ -1,0 +1,12 @@
+package com.android.sample.ui.farmer
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun OverviewScreen() {
+    //temp implementation for testing
+    Text(text = "Overview Screen")
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/OverviewScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/OverviewScreen.kt
@@ -1,12 +1,41 @@
 package com.android.sample.ui.farmer
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
+import com.android.sample.ui.navigation.BottomNavigationMenu
+import com.android.sample.ui.navigation.NavigationActions
+import com.android.sample.ui.navigation.NavigationTestTags
+import com.android.sample.ui.navigation.Tab
 
 @Preview
 @Composable
-fun OverviewScreen() {
-    //temp implementation for testing
-    Text(text = "Overview Screen")
+fun OverviewScreen(
+    onAddReport: () -> Unit = {},
+    onSignedOut: () -> Unit = {},
+    navigationActions: NavigationActions? = null,
+) {
+  // temp implementation for testing
+  Scaffold(
+      bottomBar = {
+        BottomNavigationMenu(
+            selectedTab = Tab.Overview,
+            onTabSelected = { tab -> navigationActions?.navigateTo(tab.destination) },
+            modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU))
+      },
+      content = { pd ->
+        Column {
+          Text(text = "Overview Screen")
+          Button(onClick = onAddReport, modifier = Modifier.padding(pd)) {
+            Text(text = "Add Report")
+          }
+          Button(onClick = onSignedOut, modifier = Modifier.padding(pd)) { Text(text = "Sign Out") }
+        }
+      })
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/OverviewScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/farmer/OverviewScreen.kt
@@ -1,6 +1,7 @@
 package com.android.sample.ui.farmer
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
@@ -14,6 +15,11 @@ import com.android.sample.ui.navigation.NavigationActions
 import com.android.sample.ui.navigation.NavigationTestTags
 import com.android.sample.ui.navigation.Tab
 
+object OverviewScreenTestTags {
+  const val ADD_REPORT_BUTTON = "addReportFab"
+  const val LOGOUT_BUTTON = "logoutButton"
+}
+
 @Preview
 @Composable
 fun OverviewScreen(
@@ -23,6 +29,9 @@ fun OverviewScreen(
 ) {
   // temp implementation for testing
   Scaffold(
+      topBar = {
+        Row { Text("Overview", modifier = Modifier.testTag(NavigationTestTags.TOP_BAR_TITLE)) }
+      },
       bottomBar = {
         BottomNavigationMenu(
             selectedTab = Tab.Overview,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/BottomNavigationMenu.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/BottomNavigationMenu.kt
@@ -37,11 +37,11 @@ private val tabs =
 /**
  * A reusable Bottom Navigation Bar built with Material 3 [NavigationBar].
  *
- * This composable provides a simple way to add a consistent bottom navigation menu
- * across multiple screens in your app.
+ * This composable provides a simple way to add a consistent bottom navigation menu across multiple
+ * screens in your app.
  *
- * It displays navigation items (icons and labels) and highlights the currently selected route.
- * Each item triggers navigation when clicked.
+ * It displays navigation items (icons and labels) and highlights the currently selected route. Each
+ * item triggers navigation when clicked.
  *
  * Example usage:
  * ```
@@ -58,12 +58,10 @@ private val tabs =
  * }
  * ```
  *
- * @param selectedTab The route (or destination) that is currently active.
- * Used to highlight the selected navigation item.
- *
- * @param onTabSelected Callback triggered when a navigation item is clicked.
- * Receives the target route as a parameter.
- *
+ * @param selectedTab The route (or destination) that is currently active. Used to highlight the
+ *   selected navigation item.
+ * @param onTabSelected Callback triggered when a navigation item is clicked. Receives the target
+ *   route as a parameter.
  * @param modifier Optional [Modifier] for styling or to add test tags.
  */
 @Composable

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/BottomNavigationMenu.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/BottomNavigationMenu.kt
@@ -1,0 +1,92 @@
+package com.android.sample.ui.navigation
+
+//noinspection UsingMaterialAndMaterial3Libraries
+//noinspection UsingMaterialAndMaterial3Libraries
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Place
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+// file taken from https://github.com/swent-epfl/bootcamp-25-B3-Solution/tree/main
+sealed class Tab(val name: String, val icon: ImageVector, val destination: Screen) {
+  object Overview : Tab("Overview", Icons.Outlined.Menu, Screen.Overview)
+
+  object Map : Tab("Map", Icons.Outlined.Place, Screen.Map)
+}
+
+private val tabs =
+    listOf(
+        Tab.Overview,
+        Tab.Map,
+    )
+
+/**
+ * A reusable Bottom Navigation Bar built with Material 3 [NavigationBar].
+ *
+ * This composable provides a simple way to add a consistent bottom navigation menu
+ * across multiple screens in your app.
+ *
+ * It displays navigation items (icons and labels) and highlights the currently selected route.
+ * Each item triggers navigation when clicked.
+ *
+ * Example usage:
+ * ```
+ * Scaffold(
+ *     bottomBar = {
+ *         BottomNavigationBar(
+ *              selectedTab = Tab.Overview,
+ *              onTabSelected = { tab -> navigationActions?.navigateTo(tab.destination) },
+ *              modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU))
+ *         )
+ *     }
+ * ) { innerPadding ->
+ *     // Screen content here
+ * }
+ * ```
+ *
+ * @param selectedTab The route (or destination) that is currently active.
+ * Used to highlight the selected navigation item.
+ *
+ * @param onTabSelected Callback triggered when a navigation item is clicked.
+ * Receives the target route as a parameter.
+ *
+ * @param modifier Optional [Modifier] for styling or to add test tags.
+ */
+@Composable
+fun BottomNavigationMenu(
+    selectedTab: Tab,
+    onTabSelected: (Tab) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+  NavigationBar(
+      modifier =
+          modifier.fillMaxWidth().height(60.dp).testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU),
+      containerColor = MaterialTheme.colorScheme.surface,
+      content = {
+        tabs.forEach { tab ->
+          NavigationBarItem(
+              icon = { Icon(tab.icon, contentDescription = null) },
+              label = { Text(tab.name) },
+              selected = tab == selectedTab,
+              onClick = { onTabSelected(tab) },
+              modifier =
+                  Modifier.clip(RoundedCornerShape(50.dp))
+                      .testTag(NavigationTestTags.getTabTestTag(tab)))
+        }
+      },
+  )
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -1,0 +1,82 @@
+package com.android.sample.ui.navigation
+
+import androidx.navigation.NavHostController
+
+// file taken from https://github.com/swent-epfl/bootcamp-25-B3-Solution/tree/main
+
+/**
+ * Sealed class representing different screens in the app's navigation.
+ * Each screen has a route, a display name, and a flag indicating if it's a top-level destination.
+ *
+ *
+ * @property route The unique route string used for navigation within the NavHost.
+ * @property name A human-readable label for the screen, typically shown in UI elements like the top bar.
+ * @property isTopLevelDestination Whether this screen is considered a top-level destination
+ * (e.g., shown in a BottomNavigationBar).
+ */
+sealed class Screen(
+    val route: String,
+    val name: String,
+    val isTopLevelDestination: Boolean = false
+) {
+  object Auth : Screen(route = "auth", name = "Authentication")
+
+  object Overview : Screen(route = "overview", name = "Overview", isTopLevelDestination = true)
+
+  object AddReport : Screen(route = "add_report", name = "Create a new report")
+
+  object Map : Screen(route = "map", name = "Map", isTopLevelDestination = true)
+}
+
+open class NavigationActions(
+    private val navController: NavHostController,
+) {
+  /**
+   * Navigate to the specified screen.
+   *
+   * @param screen The screen to navigate to
+   */
+  open fun navigateTo(screen: Screen) {
+    if (screen.isTopLevelDestination && currentRoute() == screen.route) {
+      // If the user is already on the top-level destination, do nothing
+      return
+    }
+    navController.navigate(screen.route) {
+      if (screen.isTopLevelDestination) {
+        launchSingleTop = true
+        popUpTo(screen.route) { inclusive = true }
+      }
+      //      restoreState = true
+      //      restoreState = true
+      //      if (screen.isTopLevelDestination) {
+      //        // Pop up to the start destination of the graph to
+      //        // avoid building up a large stack of destinations
+      //        popUpTo(navController.graph.findStartDestination().id) {
+      //          saveState = true
+      //          inclusive = true
+      //        }
+      //        // Avoid multiple copies of the same destination when reselecting same item
+      //        launchSingleTop = true
+      //      }
+      //
+      if (screen !is Screen.Auth) {
+        // Restore state when reselecting a previously selected item
+        restoreState = true
+      }
+    }
+  }
+
+  /** Navigate back to the previous screen. */
+  open fun goBack() {
+    navController.popBackStack()
+  }
+
+  /**
+   * Get the current route of the navigation controller.
+   *
+   * @return The current route
+   */
+  open fun currentRoute(): String {
+    return navController.currentDestination?.route ?: ""
+  }
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/NavigationActions.kt
@@ -5,14 +5,14 @@ import androidx.navigation.NavHostController
 // file taken from https://github.com/swent-epfl/bootcamp-25-B3-Solution/tree/main
 
 /**
- * Sealed class representing different screens in the app's navigation.
- * Each screen has a route, a display name, and a flag indicating if it's a top-level destination.
- *
+ * Sealed class representing different screens in the app's navigation. Each screen has a route, a
+ * display name, and a flag indicating if it's a top-level destination.
  *
  * @property route The unique route string used for navigation within the NavHost.
- * @property name A human-readable label for the screen, typically shown in UI elements like the top bar.
- * @property isTopLevelDestination Whether this screen is considered a top-level destination
- * (e.g., shown in a BottomNavigationBar).
+ * @property name A human-readable label for the screen, typically shown in UI elements like the top
+ *   bar.
+ * @property isTopLevelDestination Whether this screen is considered a top-level destination (e.g.,
+ *   shown in a BottomNavigationBar).
  */
 sealed class Screen(
     val route: String,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/NavigationTestTags.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/sample/ui/navigation/NavigationTestTags.kt
@@ -1,0 +1,16 @@
+package com.android.sample.ui.navigation
+
+// file taken from https://github.com/swent-epfl/bootcamp-25-B3-Solution/tree/main
+object NavigationTestTags {
+  const val BOTTOM_NAVIGATION_MENU = "BottomNavigationMenu"
+  const val GO_BACK_BUTTON = "GoBackButton"
+  const val TOP_BAR_TITLE = "TopBarTitle"
+  const val OVERVIEW_TAB = "OverviewTab"
+  const val MAP_TAB = "MapTab"
+
+  fun getTabTestTag(tab: Tab): String =
+      when (tab) {
+        is Tab.Overview -> OVERVIEW_TAB
+        is Tab.Map -> MAP_TAB
+      }
+}

--- a/AgriHealth-Alert-main/gradle/libs.versions.toml
+++ b/AgriHealth-Alert-main/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ lifecycleRuntimeKtx = "2.7.0"
 kaspresso = "1.5.5"
 robolectric = "4.11.1"
 sonar = "6.3.1.5724"
+navigationCompose = "2.7.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -40,6 +41,7 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# Summary
this PR introduces the basic navigation logic between screen. It is intended to be easily expendable depending on which screen will be implemented in the future. It is based heavily on what was done in the boot camp.
## Changes
- Add a AgriHealthApp where all the logic between screens can be handled, the logic between the first screens is already implemented.
- Add a BottomNavigationMenu function that can be implemented in all the screens that need a bottom bar,
- Add Screen a sealed class useful to represent the screens their route and name(title at the top bar).
- Add test tags and temporary screen implementations for debugging purposes that are meant to be modified.