### PR TITLE
hotfix(firebase): Commit Firebase config files

### DIFF
--- a/AgriHealth-Alert-main/.firebaserc
+++ b/AgriHealth-Alert-main/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "agrihealth-alert"
+  }
+}

--- a/AgriHealth-Alert-main/firebase.json
+++ b/AgriHealth-Alert-main/firebase.json
@@ -1,0 +1,14 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}


### PR DESCRIPTION
Hotfix that adds the required Firebase config files to the repo. For convenience, so that not everyone has to run `firebase init` on their own machine.

Note that this does *not* include `google-services.json`, which was sent through Telegram and Discord and is also required for Firebase to work.
