### PR TITLE
fix(firebase): Remove emulators from MainActivity

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/MainActivity.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/MainActivity.kt
@@ -1,11 +1,13 @@
 package com.android.agrihealth
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
@@ -24,15 +26,13 @@ import com.android.agrihealth.ui.farmer.OverviewScreen
 import com.android.agrihealth.ui.navigation.NavigationActions
 import com.android.agrihealth.ui.navigation.Screen
 import com.android.agrihealth.ui.theme.SampleAppTheme
+import com.google.firebase.BuildConfig
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
-    Firebase.firestore.useEmulator("10.0.2.2", 8080)
-    Firebase.auth.useEmulator("10.0.2.2", 9099)
-
     super.onCreate(savedInstanceState)
     setContent {
       SampleAppTheme {


### PR DESCRIPTION
This makes it possible to use the app from standalone devices, to make a tech demo possible next friday

Temporary-ish solution, until I can try setting up a remote emulator saturday/sunday. We will then see which option we keep