### PR TITLE
Add the build-apk file to main.

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,42 @@
+name: Build APK
+
+# Triggers
+on:
+  push:
+    branches:
+      - M1          # Run automatically on M1 branch
+  workflow_dispatch:  # Allows manual run
+
+jobs:
+  build:
+    name: Build Debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      #Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      #Set up Java JDK 17
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      #Add google services file
+      - name: Add google services json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES }}" | base64 --decode > AgriHealth-Alert-main/app/google-services.jsonRe
+
+      #Build the debug APK
+      - name: Build APK
+        run: cd AgriHealth-Alert-main && ./gradlew assembleDebug
+
+      #Upload the APK as artifact
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: M1-APK
+          path: AgriHealth-Alert-main/app/build/outputs/apk/debug/app-debug.apk
+          overwrite: true


### PR DESCRIPTION
Adds build-apk.yml that builds an APK on every push to main or manually in the Actions tab.

The file needs to be on main to allow the use of workflow dispatch.
It was already tested on the branch M1.