### PR TITLE
Fix(test) Check map displayed before tests.

### DIFF
--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/E2ETest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/E2ETest.kt
@@ -340,6 +340,9 @@ class E2ETest : FirebaseEmulatorsTest() {
     createReport("Report title", "Report description", vetId)
     clickFirstReportItem()
     reportViewClickViewOnMap()
+    composeTestRule.waitUntil(5000) {
+      composeTestRule.onNodeWithTag(MapScreenTestTags.GOOGLE_MAP_SCREEN).isDisplayed()
+    }
     composeTestRule.clickFirstReportMarker()
     mapClickViewReport()
     goBack()


### PR DESCRIPTION
### Fix test timing for e2e Test
---
#### Summary
- Add a check for map display before looking for map marker.
-  This should fix the inconsistency with `testFarmer_SignIn_ClickReport_Back_Logout()` in CI.
---
#### How to test changes.
- You can look at the CI and rerun it multiple time and the `testFarmer_SignIn_ClickReport_Back_Logout()` should not fail.
#### Implementation details.
- Added a check for map display before checking the markers.
