### PR TITLE
Fix map api key in github action apk.

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -38,7 +38,7 @@ jobs:
 
       #add map api key
       - name: Add map api key
-        run: echo "MAPS_API_KEY=${{screts.MAPS_API_KEY}}" > AgriHealth-Alert-main/local.properties
+        run: echo "MAPS_API_KEY=${{secrets.MAPS_API_KEY}}" > AgriHealth-Alert-main/local.properties
 
       #Build the debug APK
       - name: Build APK


### PR DESCRIPTION
### #185 Fix map api key in github action apk.
---
#### Summary
- This PR adds the map api key to local.properties when building from the CI.
### Information for the reviewer.
---
#### How to test changes.
- download the latest APK from the github action and see the map is properly displaying.
#### Implementation details.
- Since the api key is supposed to not be public I use a secret and create the local.properties at run time.