### PR TITLE
Fix double tap blank screen

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/navigation/NavigationActions.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/navigation/NavigationActions.kt
@@ -93,7 +93,7 @@ open class NavigationActions(
 
   /** Navigate back to the previous screen. */
   open fun goBack() {
-    navController.popBackStack()
+    navController.navigateUp()
   }
 
   /**


### PR DESCRIPTION
### #205 Fix double tap blank screen
---
#### Summary
- This PR fixes the bug where double tapping the go back button would make the screen blank, requiring the user to rotate their screen to fix the display.
### Information for the reviewer.
---
#### How to test changes.
- Go to the `AddReportScreen`, press quickly the go back button twice, make sure the overview displays properly.
#### Implementation details.
- I replaced `popBackStack()` by `navigateUp()` which seems to just be equivalent but the latter is safer against double tapping, this could change the behavior of the app is unforeseen ways but to my knowledge it should not.
#### Additional Notes.
- This PR doesn't include any tests because compose doesn't allow to double click the navigation button before the navigation happens.
