### PR TITLE
Fix(test): remove click on marker after viewing on map.

### DIFF
--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/E2ETest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/E2ETest.kt
@@ -418,7 +418,6 @@ class E2ETest : FirebaseEmulatorsTest() {
     composeTestRule.waitUntil(TestConstants.LONG_TIMEOUT) {
       composeTestRule.onNodeWithTag(MapScreenTestTags.GOOGLE_MAP_SCREEN).isDisplayed()
     }
-    composeTestRule.clickFirstReportMarker()
   }
 
   private fun mapClickViewReport() {


### PR DESCRIPTION
- Map now opens the Report if viewed from map, so this step is removed from reportViewClickViewOnMap in the e2e tests.

#### Summary
small fix regarding the end to end test logic linked to the new implementation of map.
The end to end test `testFarmer_SignIn_ClickReport_Back_Logout` would click view on map then click a random marker to see the `ShowReportInfo` field on the map, but now the map open the `ShowReportInfo` of the related report when clicking the view on map button from `ReportViewScreen`.
This Fix remove the click on a random marker because it would often click the same report marker and deselect it which would hide the `ShowReportInfo` field.
