### PR TITLE
fix default office.

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -71,7 +71,7 @@ fun EditProfileScreen(
   var address by remember { mutableStateOf(user.address?.toString() ?: "") }
 
   // Farmer-specific states
-  var selectedDefaultOffice by remember { mutableStateOf((user as? Farmer)?.defaultOffice ?: "") }
+  var selectedDefaultOffice by remember { mutableStateOf((user as? Farmer)?.defaultOffice) }
   var expandedVetDropdown by remember { mutableStateOf(false) }
 
   Scaffold(


### PR DESCRIPTION
### #306 fix default office.
---
#### Summary
- when adding your first office, you will now have it set as your default office.
---
#### How to test changes.
- create a **new farmer**, add an office, check your profile.
#### Implementation details.
- the edit profile was setting the defaultOffice to `""` which broke the logic.
