### PR TITLE
Google account creation fix.

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/MainActivity.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/MainActivity.kt
@@ -155,7 +155,8 @@ fun AgriHealthApp(
         RoleSelectionScreen(
             credentialManager = credentialManager,
             onBack = { navigationActions.navigateTo(Screen.Auth) },
-            onButtonPressed = { navigationActions.navigateTo(Screen.EditProfile) })
+            onButtonPressed = { navigationActions.navigateTo(Screen.EditProfile) },
+            userViewModel = userViewModel)
       }
     }
 


### PR DESCRIPTION
### #328 Google account creation fix.
---
#### Summary
- Fix a bug that made new google accounts show stale data from the previously logged in user in the edit profile screen.
#### How to test changes.
- Log in to an account.
- Log out.
- create a google account.
- check that the profile screen displays the right info.
#### Implementation details.
- Gave the role selection screen the real `userViewModel` so it updates the current user for real.
