### PR TITLE
Increase timeout for instrumentation tests to 60 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           -d '{"signIn": {"allowDuplicateEmails": true}}'
 
       - name: Run instrumentation tests
-        timeout-minutes: 25
+        timeout-minutes: 60
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34


### PR DESCRIPTION
### #366  Hotfix CI timeout
---
#### Summary
- Extend the timeout for 'Run instrumentalisation Test' from 25 to 60 minutes.
- This is an "ugly" approach, but will at least help us managing the CI until the end of the project.
#### How to test changes.
- Just check if the CI behaves as intended and this does not create any new bug.
#### Implementation details.
- Just changed the `timeout-minutes` from 25 to 60.
#### Additional Notes.
- Nothing more
