### PR TITLE
Fix AddReportScreen

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/report/AddReportScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/report/AddReportScreen.kt
@@ -348,9 +348,7 @@ fun OfficeDropdown(
     onOfficeSelected: (String) -> Unit
 ) {
   var expanded by remember { mutableStateOf(false) }
-  var selectedOfficeName by remember {
-    mutableStateOf(offices[selectedOfficeId] ?: selectedOfficeId)
-  }
+  var selectedOfficeName = offices[selectedOfficeId] ?: selectedOfficeId
 
   ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
     OutlinedTextField(
@@ -523,9 +521,7 @@ fun UploadRemovePhotoButton(
     Text(
         text =
             if (photoAlreadyPicked) AddReportUploadButtonTexts.REMOVE_IMAGE
-            else AddReportUploadButtonTexts.UPLOAD_IMAGE,
-        style = MaterialTheme.typography.titleLarge,
-    )
+            else AddReportUploadButtonTexts.UPLOAD_IMAGE)
   }
 }
 
@@ -562,7 +558,7 @@ fun CreateReportButton(
   Button(
       onClick = onClick,
       modifier = Modifier.fillMaxWidth().testTag(AddReportScreenTestTags.CREATE_BUTTON)) {
-        Text("Create Report", style = MaterialTheme.typography.titleLarge)
+        Text("Create Report")
       }
 }
 


### PR DESCRIPTION
### #372 Fix AddReportScreen
---
#### Summary
- Fixed `AddReportScreen` Office dropdown, to display the `Default Office` on screen launch (as it was already doing before).
- This should help fix the tests in other PRs currently blocked. 
### Information for the team.
---
#### How to test changes.
- Check the `AddReportScreen` UI and check the default Vet is directly exposed on the screen.
