### PR TITLE
Hotfix/Upgrade Java version to 21 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'zulu'
           
       - name: Retrieve gradle cache


### PR DESCRIPTION
### #381 Fix deprecated Java in CI
---
#### Summary
- Changes the Java version from the deprecated 17 to the brand new and awesome 21
- This is necessary to run Firebase emulators, which the CI depends on
### Information for the team.
---
#### How to test changes.
- Run the CI
- Check that it doesn't explode after 4 minutes when running Firebase emulators
#### Implementation details.
- Very lazy fix, seems to work though. We already use Java 21 in our project so I don't see why it wouldn't work
#### Additional Notes.
- Branch name is terrible, I wanted to fix this ASAP so I did it via GitHub and forgot to check the name of the branch
