### PR TITLE
Fix(navigation): Fix #294.

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/navigation/NavigationActions.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/navigation/NavigationActions.kt
@@ -57,7 +57,8 @@ sealed class Screen(
     }
   }
 
-  data class ViewUser(val uid: String) : Screen(route = "view_user/${uid}", name = "View User") {
+  data class ViewUser(val uid: String) :
+      Screen(route = "view_user/${uid.ifEmpty { " " }}", name = "View User") {
     companion object {
       const val route = "view_user/{uid}"
     }


### PR DESCRIPTION
### #294  navigation to ViewUser when farmerId is empty ("")
#### Summary
- add condition to the route to avoid navigating to "view_user/"
- "view_user/" did not match the route defined in the navigation graph, "view_user/{uid}", which requires a non-empty argument. Since no destination matched the generated route, NavController threw an IllegalArgumentException.
### Information for the team.
---
#### Solved issues. (optional)
- closes #294.
- the issue is similar to #307 but was fixed differently.
### Information for the reviewer.
---
#### How to test changes.
- To obtain a Deleted User from the vet overview i had to hard code it because but maybe you will find a concrete way to delete users.
#### Implementation details.
- Adding a condition to the route instead of making sure Screen.ViewUser is never called with empty string (as it was done in #307), insures that the issue never happens.
