### PR TITLE
Demo/profile pictures users

### DIFF
--- a/AgriHealth-Alert-main/app/build.gradle.kts
+++ b/AgriHealth-Alert-main/app/build.gradle.kts
@@ -207,7 +207,9 @@ dependencies {
     implementation("androidx.exifinterface:exifinterface:1.3.7")
 
     // ---- Used for cropping images -----
-    implementation("com.vanniktech:android-image-cropper:4.3.3")
+    //implementation("com.vanniktech:android-image-cropper:4.3.3")
+    //implementation("com.github.Tanish-Ranjan:crop-kit:version")
+    implementation("io.github.mr0xf00:easycrop:0.1.1")
 
 }
 

--- a/AgriHealth-Alert-main/app/build.gradle.kts
+++ b/AgriHealth-Alert-main/app/build.gradle.kts
@@ -206,6 +206,9 @@ dependencies {
     // ---- For EXIF data manipulation ------
     implementation("androidx.exifinterface:exifinterface:1.3.7")
 
+    // ---- Used for cropping images -----
+    implementation("com.vanniktech:android-image-cropper:4.3.3")
+
 }
 
 tasks.withType<Test> {

--- a/AgriHealth-Alert-main/app/build.gradle.kts
+++ b/AgriHealth-Alert-main/app/build.gradle.kts
@@ -207,9 +207,7 @@ dependencies {
     implementation("androidx.exifinterface:exifinterface:1.3.7")
 
     // ---- Used for cropping images -----
-    //implementation("com.vanniktech:android-image-cropper:4.3.3")
-    //implementation("com.github.Tanish-Ranjan:crop-kit:version")
-    implementation("io.github.mr0xf00:easycrop:0.1.1")
+    implementation(libs.easycrop)
 
 }
 

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/E2ETest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/E2ETest.kt
@@ -489,7 +489,7 @@ class E2ETest : FirebaseEmulatorsTest() {
       composeTestRule.onNodeWithText("Office successfully added!").isDisplayed()
     }
     goBack()
-    waitUntilTestTag(ProfileScreenTestTags.PROFILE_IMAGE)
+    waitUntilTestTag(ProfileScreenTestTags.PROFILE_PICTURE)
   }
 
   private fun vetJoinOffice(vetCode: String) {
@@ -701,7 +701,7 @@ class E2ETest : FirebaseEmulatorsTest() {
 
     composeTestRule.onNodeWithTag(ManageOfficeScreenTestTags.CONFIRM_LEAVE).performClick()
 
-    waitUntilTestTag(ProfileScreenTestTags.PROFILE_IMAGE)
+    waitUntilTestTag(ProfileScreenTestTags.PROFILE_PICTURE)
   }
 
   private fun checkLinkedVetIsNotEmpty() {
@@ -789,7 +789,7 @@ class E2ETest : FirebaseEmulatorsTest() {
         .assertIsDisplayed()
         .performClick()
 
-    waitUntilTestTag(ProfileScreenTestTags.PROFILE_IMAGE)
+    waitUntilTestTag(ProfileScreenTestTags.PROFILE_PICTURE)
   }
 
   private fun checkIsGoogleAccount() {
@@ -1002,7 +1002,7 @@ class E2ETest : FirebaseEmulatorsTest() {
         .onNodeWithTag(OverviewScreenTestTags.PROFILE_BUTTON)
         .assertIsDisplayed()
         .performClick()
-    waitUntilTestTag(ProfileScreenTestTags.PROFILE_IMAGE)
+    waitUntilTestTag(ProfileScreenTestTags.PROFILE_PICTURE)
   }
 
   private fun clickAddVetCode() {

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/profile/ProfileScreenTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/profile/ProfileScreenTest.kt
@@ -22,7 +22,7 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.CODE_BUTTON_FARME
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.DEFAULT_OFFICE_FIELD
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.EDIT_BUTTON
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.NAME_TEXT
-import com.android.agrihealth.ui.profile.ProfileScreenTestTags.PROFILE_IMAGE
+import com.android.agrihealth.ui.profile.ProfileScreenTestTags.PROFILE_PICTURE
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.user.UserViewModelContract
 import java.time.LocalDate
@@ -74,7 +74,7 @@ class ProfileScreenTest {
                 address = null))
     setScreen(vm)
 
-    composeTestRule.onNodeWithTag(PROFILE_IMAGE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PROFILE_PICTURE).assertIsDisplayed()
   }
 
   @Test
@@ -185,7 +185,7 @@ class ProfileScreenTest {
             Farmer("1", "Alice", "Johnson", "alice@farmmail.com", null, defaultOffice = null))
     setScreen(vm)
 
-    composeTestRule.onNodeWithTag(PROFILE_IMAGE).assertExists()
+    composeTestRule.onNodeWithTag(PROFILE_PICTURE).assertExists()
     composeTestRule.onNodeWithTag(GO_BACK_BUTTON).assertExists()
     composeTestRule.onNodeWithTag(LOGOUT_BUTTON).assertExists()
     composeTestRule.onNodeWithTag(EDIT_BUTTON).assertExists()

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/user/ViewUserScreenTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/user/ViewUserScreenTest.kt
@@ -12,8 +12,6 @@ import com.android.agrihealth.data.model.user.Vet
 import com.android.agrihealth.testutil.FakeOfficeRepository
 import com.android.agrihealth.testutil.FakeUserRepository
 import com.android.agrihealth.testutil.TestConstants
-import com.android.agrihealth.ui.profile.PhotoComponentsTestTags
-import com.android.agrihealth.ui.utils.ProfilePictureComponentsTestTags
 import org.junit.Rule
 import org.junit.Test
 

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/user/ViewUserScreenTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/user/ViewUserScreenTest.kt
@@ -12,6 +12,8 @@ import com.android.agrihealth.data.model.user.Vet
 import com.android.agrihealth.testutil.FakeOfficeRepository
 import com.android.agrihealth.testutil.FakeUserRepository
 import com.android.agrihealth.testutil.TestConstants
+import com.android.agrihealth.ui.profile.PhotoComponentsTestTags
+import com.android.agrihealth.ui.utils.ProfilePictureComponentsTestTags
 import org.junit.Rule
 import org.junit.Test
 
@@ -125,7 +127,7 @@ class ViewUserScreenTest {
     setScreen(vm)
 
     composeTestRule
-        .onNodeWithTag(ViewUserScreenTestTags.PROFILE_ICON)
+        .onNodeWithTag(ViewUserScreenTestTags.PROFILE_PICTURE)
         .assertExists()
         .assertIsDisplayed()
   }
@@ -265,7 +267,7 @@ class ViewUserScreenTest {
     setScreen(vm)
 
     composeTestRule.onNodeWithTag(ViewUserScreenTestTags.TOP_BAR).assertExists()
-    composeTestRule.onNodeWithTag(ViewUserScreenTestTags.PROFILE_ICON).assertExists()
+    composeTestRule.onNodeWithTag(ViewUserScreenTestTags.PROFILE_PICTURE).assertExists()
     composeTestRule.onNodeWithTag(ViewUserScreenTestTags.NAME_FIELD).assertExists()
     composeTestRule.onNodeWithTag(ViewUserScreenTestTags.ROLE_FIELD).assertExists()
     composeTestRule.onNodeWithTag(ViewUserScreenTestTags.CONTENT_COLUMN).assertExists()

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/utils/ProfilePictureComponentsTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/utils/ProfilePictureComponentsTest.kt
@@ -1,0 +1,133 @@
+package com.android.agrihealth.ui.utils
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.agrihealth.data.model.images.ImageViewModel
+import com.android.agrihealth.testutil.FakeImageRepository
+import com.android.agrihealth.testutil.TestConstants.SHORT_TIMEOUT
+import com.android.agrihealth.ui.profile.PhotoComponentsTestTags
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ProfilePictureComponentsTest {
+  @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun errorDialog_rendersCorrectly() {
+    val title = "Error!"
+    val message = "Something failed"
+
+    var show by mutableStateOf(true)
+    var wasDismissed by mutableStateOf(false)
+
+    composeTestRule.setContent {
+      MaterialTheme {
+        if (show) {
+          ErrorDialog(
+              dialogTitle = title,
+              errorMessage = message,
+              onDismiss = {
+                wasDismissed = true
+                show = false
+              })
+        }
+      }
+    }
+
+    composeTestRule.onNodeWithTag(ProfilePictureComponentsTestTags.ERROR_DIALOG).assertIsDisplayed()
+
+    composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    composeTestRule.onNodeWithText(message).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(ProfilePictureComponentsTestTags.ERROR_DIALOG_OK_BUTTON)
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .assertTextEquals(ProfilePictureComponentsTexts.ERROR_DIALOG_OK)
+
+    wasDismissed = false
+    composeTestRule
+        .onNodeWithTag(ProfilePictureComponentsTestTags.ERROR_DIALOG_OK_BUTTON)
+        .performClick()
+    assertTrue(wasDismissed)
+
+    composeTestRule.waitForIdle()
+
+    composeTestRule
+        .onNodeWithTag(ProfilePictureComponentsTestTags.ERROR_DIALOG)
+        .assertIsNotDisplayed()
+  }
+
+  @Test
+  fun profilePicture_defaultIcon_IsShown() {
+    composeTestRule.setContent { MaterialTheme { ProfilePicture(photo = PhotoUi.Empty) } }
+
+    composeTestRule.waitUntil(SHORT_TIMEOUT) {
+      composeTestRule
+          .onAllNodesWithTag(PhotoComponentsTestTags.DEFAULT_ICON)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.DEFAULT_ICON).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.PHOTO_RENDER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.IMAGE_PREVIEW).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun profilePicture_localPhoto_IsShown() {
+    val photo = byteArrayOf(1, 2, 3, 4, 5, 6)
+    composeTestRule.setContent { MaterialTheme { ProfilePicture(photo = PhotoUi.Local(photo)) } }
+
+    composeTestRule.waitUntil(SHORT_TIMEOUT) {
+      composeTestRule
+          .onAllNodesWithTag(PhotoComponentsTestTags.IMAGE_PREVIEW)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.IMAGE_PREVIEW).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.PHOTO_RENDER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.DEFAULT_ICON).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun profilePicture_remotePhoto_IsShown() {
+    val fakeImageRepository = FakeImageRepository(connectionIsFrozen = false)
+    fakeImageRepository.forceUploadImage(byteArrayOf(1, 2, 3, 4, 5, 6))
+    val imageViewModel = ImageViewModel(fakeImageRepository)
+
+    composeTestRule.setContent {
+      MaterialTheme {
+        ProfilePicture(photo = PhotoUi.Remote("fake/example/path"), imageViewModel = imageViewModel)
+      }
+    }
+
+    composeTestRule.waitUntil(SHORT_TIMEOUT) {
+      composeTestRule
+          .onAllNodesWithTag(PhotoComponentsTestTags.PHOTO_RENDER)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.PHOTO_RENDER).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.IMAGE_PREVIEW).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(PhotoComponentsTestTags.DEFAULT_ICON).assertIsNotDisplayed()
+  }
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/authentification/UserRepositoryFirestore.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/authentification/UserRepositoryFirestore.kt
@@ -67,7 +67,8 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore = Firebase.fires
             "isGoogleAccount" to user.isGoogleAccount,
             "description" to user.description,
             "collected" to user.collected,
-            "deviceTokensFCM" to user.deviceTokensFCM.toList())
+            "deviceTokensFCM" to user.deviceTokensFCM.toList(),
+            "photoURL" to user.photoURL)
 
     // Add type-specific fields
     when (user) {
@@ -99,6 +100,7 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore = Firebase.fires
     val addressData = data["address"] as? Map<*, *>
     val address = locationFromMap(addressData)
     val deviceTokensFCM = (data["deviceTokensFCM"] as? List<String>)?.toSet() ?: emptySet()
+    val photoURL = data["photoURL"] as? String
 
     return when (roleFromDisplayString(roleStr)) {
       UserRole.FARMER ->
@@ -113,7 +115,8 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore = Firebase.fires
               isGoogleAccount = isGoogleAccount,
               description = description,
               collected = collected,
-              deviceTokensFCM = deviceTokensFCM)
+              deviceTokensFCM = deviceTokensFCM,
+              photoURL = photoURL)
       UserRole.VET ->
           Vet(
               uid = uid,
@@ -127,7 +130,8 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore = Firebase.fires
               isGoogleAccount = isGoogleAccount,
               description = description,
               collected = collected,
-              deviceTokensFCM = deviceTokensFCM)
+              deviceTokensFCM = deviceTokensFCM,
+              photoURL = photoURL)
       else -> throw Exception("Unknown user type: $roleStr")
     }
   }
@@ -144,6 +148,7 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore = Firebase.fires
     if (old.collected != new.collected) changes["collected"] = new.collected
     if (old.deviceTokensFCM != new.deviceTokensFCM)
         changes["deviceTokensFCM"] = new.deviceTokensFCM.toList()
+    if (old.photoURL != new.photoURL) changes["photoURL"] = new.photoURL
 
     when {
       old is Farmer && new is Farmer -> {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageViewModel.kt
@@ -25,13 +25,14 @@ sealed class ImageUIState {
 }
 
 /**
- *  A union type so that a photo can either be stored in a ByteArray or in a Uri.
+ * A union type so that a photo can either be stored in a ByteArray or in a Uri.
  *
- *  This is meant as an internal type, it should not appear in any public interface. It is meant
- *  to be used internally when overloading a function
+ * This is meant as an internal type, it should not appear in any public interface. It is meant to
+ * be used internally when overloading a function
  */
 sealed interface PhotoType {
   data class ByteArray(val bytes: kotlin.ByteArray) : PhotoType
+
   data class Uri(val uri: android.net.Uri) : PhotoType
 }
 
@@ -61,16 +62,17 @@ class ImageViewModel(private val repository: ImageRepository = ImageRepositoryPr
     viewModelScope.launch {
       _uiState.value = ImageUIState.Loading
 
-      var bytes = when (photo) {
-        is PhotoType.ByteArray -> photo.bytes
-        is PhotoType.Uri -> repository.resolveUri(photo.uri)
-      }
+      var bytes =
+          when (photo) {
+            is PhotoType.ByteArray -> photo.bytes
+            is PhotoType.Uri -> repository.resolveUri(photo.uri)
+          }
       bytes = repository.reduceFileSize(bytes)
 
       repository
-        .uploadImage(bytes)
-        .onSuccess { path -> _uiState.value = ImageUIState.UploadSuccess(path) }
-        .onFailure { e -> _uiState.value = ImageUIState.Error(e) }
+          .uploadImage(bytes)
+          .onSuccess { path -> _uiState.value = ImageUIState.UploadSuccess(path) }
+          .onFailure { e -> _uiState.value = ImageUIState.Error(e) }
     }
   }
 
@@ -85,7 +87,8 @@ class ImageViewModel(private val repository: ImageRepository = ImageRepositoryPr
   }
 
   /**
-   * Starts uploading the photo referenced by the given [uri] and suspends until the upload finishes.
+   * Starts uploading the photo referenced by the given [uri] and suspends until the upload
+   * finishes.
    *
    * @return The URL of the uploaded photo on success.
    * @throws Throwable If the upload fails (rethrows the underlying error).

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageViewModel.kt
@@ -31,8 +31,8 @@ sealed class ImageUIState {
  *  to be used internally when overloading a function
  */
 sealed interface PhotoType {
-  data class ByteArray(val value: kotlin.ByteArray) : PhotoType
-  data class Uri(val value: android.net.Uri) : PhotoType
+  data class ByteArray(val bytes: kotlin.ByteArray) : PhotoType
+  data class Uri(val uri: android.net.Uri) : PhotoType
 }
 
 /**
@@ -62,8 +62,8 @@ class ImageViewModel(private val repository: ImageRepository = ImageRepositoryPr
       _uiState.value = ImageUIState.Loading
 
       var bytes = when (photo) {
-        is PhotoType.ByteArray -> photo.value
-        is PhotoType.Uri -> repository.resolveUri(photo.value)
+        is PhotoType.ByteArray -> photo.bytes
+        is PhotoType.Uri -> repository.resolveUri(photo.uri)
       }
       bytes = repository.reduceFileSize(bytes)
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/user/Farmer.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/user/Farmer.kt
@@ -16,7 +16,8 @@ data class Farmer(
     override val isGoogleAccount: Boolean = false,
     override val description: String? = null,
     override val collected: Boolean = false,
-    override val deviceTokensFCM: Set<String> = emptySet()
+    override val deviceTokensFCM: Set<String> = emptySet(),
+    override val photoURL: String? = null
 ) :
     User(
         uid,
@@ -28,4 +29,5 @@ data class Farmer(
         isGoogleAccount,
         description,
         collected,
-        deviceTokensFCM)
+        deviceTokensFCM,
+        photoURL)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/user/User.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/user/User.kt
@@ -12,7 +12,8 @@ sealed class User(
     open val isGoogleAccount: Boolean = false,
     open val description: String? = null,
     open val collected: Boolean = false,
-    open val deviceTokensFCM: Set<String> = emptySet()
+    open val deviceTokensFCM: Set<String> = emptySet(),
+    open val photoURL: String? = null
 )
 
 /** Copies fields common to farmers and vets, because User is a sealed class */
@@ -25,7 +26,8 @@ fun User.copyCommon(
     isGoogleAccount: Boolean = this.isGoogleAccount,
     description: String? = this.description,
     collected: Boolean = this.collected,
-    deviceTokensFCM: Set<String> = this.deviceTokensFCM
+    deviceTokensFCM: Set<String> = this.deviceTokensFCM,
+    photoURL: String? = this.photoURL
 ): User {
   return when (this) {
     is Farmer ->
@@ -38,7 +40,8 @@ fun User.copyCommon(
             collected = collected,
             isGoogleAccount = isGoogleAccount,
             description = description,
-            deviceTokensFCM = deviceTokensFCM)
+            deviceTokensFCM = deviceTokensFCM,
+            photoURL = photoURL)
     is Vet ->
         this.copy(
             uid,
@@ -49,7 +52,8 @@ fun User.copyCommon(
             collected = collected,
             isGoogleAccount = isGoogleAccount,
             description = description,
-            deviceTokensFCM = deviceTokensFCM)
+            deviceTokensFCM = deviceTokensFCM,
+            photoURL = photoURL)
   }
 }
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/user/Vet.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/user/Vet.kt
@@ -15,7 +15,8 @@ data class Vet(
     override val isGoogleAccount: Boolean = false,
     override val description: String? = null,
     override val collected: Boolean = false,
-    override val deviceTokensFCM: Set<String> = emptySet()
+    override val deviceTokensFCM: Set<String> = emptySet(),
+    override val photoURL: String? = null
 ) :
     User(
         uid,
@@ -27,4 +28,5 @@ data class Vet(
         isGoogleAccount,
         description,
         collected,
-        deviceTokensFCM)
+        deviceTokensFCM,
+        photoURL)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -46,7 +46,6 @@ import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.SAVE_BUTTON
 import com.android.agrihealth.ui.profile.CodesViewModel
 import com.android.agrihealth.ui.profile.EditProfileScreenTestTags
 import com.android.agrihealth.ui.profile.EditProfileScreenTexts
-import com.android.agrihealth.ui.profile.ErrorDialog
 import com.android.agrihealth.ui.profile.GenerateCode
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -39,6 +41,8 @@ import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.OFFICE_NAME
 import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.OFFICE_VET_LIST
 import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.SAVE_BUTTON
 import com.android.agrihealth.ui.profile.CodesViewModel
+import com.android.agrihealth.ui.profile.EditProfileScreenTestTags
+import com.android.agrihealth.ui.profile.EditableProfilePicture
 import com.android.agrihealth.ui.profile.GenerateCode
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
@@ -127,6 +131,9 @@ fun ManageOfficeScreen(
                           Text("Join an Office")
                         }
                   } else {
+                    // TODO Use this from its own separate file
+
+
                     UploadRemoveOfficePhotoSection(
                         isOwner = isOwner,
                         photoAlreadyPicked = uiState.photoUri != null,
@@ -238,6 +245,60 @@ fun ManageOfficeScreen(
               }
         }
       }
+}
+
+
+// TODO: Put this in its own file
+@Composable
+fun EditableProfilePicture(
+  imageViewModel: ImageViewModel,
+  profilePictureIsEmpty: Boolean,
+  localPhotoUri: Uri?,
+  remotePhotoURL: String?,
+  initialLoad: Boolean,
+  handleProfilePictureClick: () -> Unit
+) {
+  Box(
+    modifier = Modifier.size(120.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+
+
+    val showRemote = initialLoad && localPhotoUri == null && remotePhotoURL != null
+
+    // TODO Make the default profile icon and the actual profile picture the same size
+    if (showRemote) {
+      RemotePhotoDisplay(
+        photoURL = remotePhotoURL,
+        imageViewModel = imageViewModel,
+        modifier = Modifier.size(120.dp).clip(CircleShape),   // TODO Create a component for Profile Picture
+        contentDescription = "Office photo",
+        showPlaceHolder = true)
+    } else {
+      LocalPhotoDisplay(
+        photoURI = localPhotoUri,
+        modifier = Modifier.size(120.dp).clip(CircleShape),
+        showPlaceHolder = true,
+      )
+    }
+
+    // Camera icon overlay
+    FloatingActionButton(
+      onClick = { handleProfilePictureClick() },
+      modifier = Modifier
+        .size(40.dp)
+        .align(Alignment.BottomEnd)
+        .testTag(EditProfileScreenTestTags.EDIT_PROFILE_PICTURE_BUTTON),
+      containerColor = MaterialTheme.colorScheme.primaryContainer,
+      contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+    ) {
+      Icon(
+        imageVector = if (profilePictureIsEmpty) Icons.Default.CameraAlt else Icons.Default.Clear,
+        contentDescription = "Edit profile picture",
+        modifier = Modifier.size(20.dp)
+      )
+    }
+  }
 }
 
 @Composable

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -320,7 +320,6 @@ fun UploadRemoveOfficePhotoSection(
   ) {
 
     var initialLoad by rememberSaveable { mutableStateOf(true) }
-    //val showRemote = initialLoad && uiState.photoBytes == null
     val showRemote = initialLoad && uiState.office?.photoUrl != null
     val showLocal = uiState.photoBytes != null
     Log.d("ManageOfficeScreen", "initialLoad = $initialLoad, (uiState.photoBytes == null) = ${uiState.photoBytes == null}, showRemote = $showRemote, showLocal = $showLocal")

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -38,8 +38,7 @@ import com.android.agrihealth.ui.profile.CodesViewModel
 import com.android.agrihealth.ui.profile.GenerateCode
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.user.UserViewModel
-import com.android.agrihealth.ui.utils.EditableProfilePictureWithUI
-import com.android.agrihealth.ui.utils.PhotoUi
+import com.android.agrihealth.ui.utils.EditableProfilePictureWithImageCropper
 import kotlinx.coroutines.launch
 
 object ManageOfficeScreenTestTags {
@@ -121,7 +120,7 @@ fun ManageOfficeScreen(
                       }
                 } else {
 
-                  EditableProfilePictureWithUI(
+                  EditableProfilePictureWithImageCropper(
                       photo = uiState.displayedPhoto,
                       isEditable = isOwner,
                       imageViewModel = imageViewModel,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -76,18 +76,6 @@ fun ManageOfficeScreen(
   var showLeaveDialog by remember { mutableStateOf(false) }
   val isOwner = uiState.office?.ownerId == currentUser.uid
 
-  // Decide what to show for the profile picture
-  val photoUi by
-      remember(uiState.office?.photoUrl, uiState.photoBytes, uiState.removeRemotePhoto) {
-        mutableStateOf(
-            when {
-              uiState.photoBytes != null -> PhotoUi.Local(uiState.photoBytes!!)
-              uiState.removeRemotePhoto -> PhotoUi.Empty
-              uiState.office?.photoUrl != null -> PhotoUi.Remote(uiState.office!!.photoUrl!!)
-              else -> PhotoUi.Empty
-            })
-      }
-
   LaunchedEffect(currentUser) { manageOfficeViewModel.loadOffice() }
 
   LaunchedEffect(uiState.snackMessage) {
@@ -134,7 +122,7 @@ fun ManageOfficeScreen(
                 } else {
 
                   EditableProfilePictureWithUI(
-                      photo = photoUi,
+                      photo = uiState.displayedPhoto,
                       isEditable = isOwner,
                       imageViewModel = imageViewModel,
                       onPhotoPicked = { bytes -> manageOfficeViewModel.setPhoto(bytes) },

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -301,6 +301,7 @@ fun EditableProfilePicture(
   }
 }
 
+// TODO Make the profile picture square for offices
 @Composable
 fun UploadRemoveOfficePhotoSection(
     isOwner: Boolean = false,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -49,6 +49,7 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.profile.RemotePhotoDisplay
 import com.android.agrihealth.ui.profile.UploadRemovePhotoButton
 import com.android.agrihealth.ui.user.UserViewModel
+import com.android.agrihealth.ui.utils.ImagePickerDialog
 import kotlinx.coroutines.launch
 
 object ManageOfficeScreenTestTags {
@@ -314,47 +315,60 @@ fun UploadRemoveOfficePhotoSection(
     imageViewModel: ImageViewModel = viewModel()
 ) {
 
-  var initialLoad by rememberSaveable { mutableStateOf(true) }
-  val showRemote = initialLoad && uiState.photoUri == null
+  Box(
+    modifier = Modifier.size(120.dp),
+    contentAlignment = Alignment.Center,
+  ) {
 
-  if (showRemote) {
-    RemotePhotoDisplay(
-        photoURL = uiState.office?.photoUrl,
-        imageViewModel = imageViewModel,
-        modifier = Modifier.size(120.dp).clip(CircleShape),
-        contentDescription = "Office photo",
-        showPlaceHolder = true)
-  } else {
-    LocalPhotoDisplay(
-        photoURI = uiState.photoUri,
-        modifier = Modifier.size(120.dp).clip(CircleShape),
-        showPlaceHolder = true)
-  }
+    var initialLoad by rememberSaveable { mutableStateOf(true) }
+    val showRemote = initialLoad && uiState.photoUri == null
 
-  if (isOwner) {
-    // Camera icon overlay
-    FloatingActionButton(
-      onClick = { handleProfilePictureClick() },
-      modifier = Modifier
-        .size(40.dp)
-        .align(Alignment.BottomEnd)
-        .testTag(EditProfileScreenTestTags.EDIT_PROFILE_PICTURE_BUTTON),
-      containerColor = MaterialTheme.colorScheme.primaryContainer,
-      contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-    ) {
-      Icon(
-        imageVector = if (profilePictureIsEmpty) Icons.Default.CameraAlt else Icons.Default.Clear,
-        contentDescription = "Edit profile picture",
-        modifier = Modifier.size(20.dp)
-      )
+    if (showRemote) {
+      RemotePhotoDisplay(
+          photoURL = uiState.office?.photoUrl,
+          imageViewModel = imageViewModel,
+          modifier = Modifier.size(120.dp).clip(CircleShape),
+          contentDescription = "Office photo",
+          showPlaceHolder = true)
+    } else {
+      LocalPhotoDisplay(
+          photoURI = uiState.photoUri,
+          modifier = Modifier.size(120.dp).clip(CircleShape),
+          showPlaceHolder = true)
     }
 
-    UploadRemovePhotoButton(
-        photoAlreadyPicked = photoAlreadyPicked,
-        onPhotoPicked = onPhotoPicked,
-        onPhotoRemoved = {
-          onPhotoRemoved()
-          initialLoad = false
-        })
+    if (isOwner) {
+      var showImagePicker by remember { mutableStateOf(false) }
+
+      // Camera icon overlay
+      FloatingActionButton(
+        onClick = { if (photoAlreadyPicked) onPhotoRemoved() else showImagePicker = true },
+        modifier = Modifier
+          .size(40.dp)
+          .align(Alignment.BottomEnd)
+          .testTag(EditProfileScreenTestTags.EDIT_PROFILE_PICTURE_BUTTON),
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+      ) {
+        Icon(
+          imageVector = if (photoAlreadyPicked) Icons.Default.Clear else Icons.Default.CameraAlt,
+          contentDescription = "Edit profile picture",
+          modifier = Modifier.size(20.dp)
+        )
+      }
+
+      if (showImagePicker) {
+        ImagePickerDialog(
+          onDismiss = { showImagePicker = false }, onImageSelected = { uri -> onPhotoPicked(uri) })
+      }
+
+//      UploadRemovePhotoButton(
+//          photoAlreadyPicked = photoAlreadyPicked,
+//          onPhotoPicked = onPhotoPicked,
+//          onPhotoRemoved = {
+//            onPhotoRemoved()
+//            initialLoad = false
+//          })
+    }
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -77,16 +77,16 @@ fun ManageOfficeScreen(
   val isOwner = uiState.office?.ownerId == currentUser.uid
 
   // Decide what to show for the profile picture
-  val photoUi by remember(uiState.office?.photoUrl, uiState.photoBytes, uiState.removeRemotePhoto) {
-    mutableStateOf(
-      when {
-        uiState.photoBytes != null -> PhotoUi.Local(uiState.photoBytes!!)
-        uiState.removeRemotePhoto -> PhotoUi.Empty
-        uiState.office?.photoUrl != null -> PhotoUi.Remote(uiState.office!!.photoUrl!!)
-        else -> PhotoUi.Empty
+  val photoUi by
+      remember(uiState.office?.photoUrl, uiState.photoBytes, uiState.removeRemotePhoto) {
+        mutableStateOf(
+            when {
+              uiState.photoBytes != null -> PhotoUi.Local(uiState.photoBytes!!)
+              uiState.removeRemotePhoto -> PhotoUi.Empty
+              uiState.office?.photoUrl != null -> PhotoUi.Remote(uiState.office!!.photoUrl!!)
+              else -> PhotoUi.Empty
+            })
       }
-    )
-  }
 
   LaunchedEffect(currentUser) { manageOfficeViewModel.loadOffice() }
 
@@ -119,129 +119,126 @@ fun ManageOfficeScreen(
               horizontalAlignment = Alignment.CenterHorizontally,
               verticalArrangement = Arrangement.Top) {
                 HorizontalDivider(modifier = Modifier.padding(bottom = 24.dp))
-                  if (uiState.office == null) {
-                    Button(
-                        onClick = onCreateOffice,
-                        modifier = Modifier.fillMaxWidth().testTag(CREATE_OFFICE_BUTTON)) {
-                          Text("Create My Office")
-                        }
+                if (uiState.office == null) {
+                  Button(
+                      onClick = onCreateOffice,
+                      modifier = Modifier.fillMaxWidth().testTag(CREATE_OFFICE_BUTTON)) {
+                        Text("Create My Office")
+                      }
 
-                    Button(
-                        onClick = onJoinOffice,
-                        modifier = Modifier.fillMaxWidth().testTag(JOIN_OFFICE_BUTTON)) {
-                          Text("Join an Office")
-                        }
-                  } else {
+                  Button(
+                      onClick = onJoinOffice,
+                      modifier = Modifier.fillMaxWidth().testTag(JOIN_OFFICE_BUTTON)) {
+                        Text("Join an Office")
+                      }
+                } else {
 
-                    EditableProfilePictureWithUI(
+                  EditableProfilePictureWithUI(
                       photo = photoUi,
                       isEditable = isOwner,
                       imageViewModel = imageViewModel,
                       onPhotoPicked = { bytes -> manageOfficeViewModel.setPhoto(bytes) },
                       onPhotoRemoved = { manageOfficeViewModel.removePhoto() },
-                    )
+                  )
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                  Spacer(modifier = Modifier.height(16.dp))
 
-                    OutlinedTextField(
-                        value = if (isOwner) uiState.editableName else uiState.office!!.name,
-                        onValueChange = { if (isOwner) manageOfficeViewModel.onNameChange(it) },
-                        label = { Text("Office Name") },
-                        enabled = isOwner,
-                        modifier = Modifier.fillMaxWidth().testTag(OFFICE_NAME))
+                  OutlinedTextField(
+                      value = if (isOwner) uiState.editableName else uiState.office!!.name,
+                      onValueChange = { if (isOwner) manageOfficeViewModel.onNameChange(it) },
+                      label = { Text("Office Name") },
+                      enabled = isOwner,
+                      modifier = Modifier.fillMaxWidth().testTag(OFFICE_NAME))
 
-                    OutlinedTextField(
-                        value =
-                            if (isOwner) uiState.editableDescription
-                            else (uiState.office!!.description ?: ""),
-                        onValueChange = {
-                          if (isOwner) manageOfficeViewModel.onDescriptionChange(it)
-                        },
-                        label = { Text("Description") },
-                        enabled = isOwner,
-                        modifier = Modifier.fillMaxWidth().testTag(OFFICE_DESCRIPTION))
+                  OutlinedTextField(
+                      value =
+                          if (isOwner) uiState.editableDescription
+                          else (uiState.office!!.description ?: ""),
+                      onValueChange = {
+                        if (isOwner) manageOfficeViewModel.onDescriptionChange(it)
+                      },
+                      label = { Text("Description") },
+                      enabled = isOwner,
+                      modifier = Modifier.fillMaxWidth().testTag(OFFICE_DESCRIPTION))
 
-                    OutlinedTextField(
-                        value = uiState.office!!.address?.name ?: "",
-                        onValueChange = { if (isOwner) manageOfficeViewModel.onAddressChange(it) },
-                        singleLine = true,
-                        readOnly = true,
-                        label = { Text("Address") },
-                        enabled = isOwner,
-                        modifier = Modifier.fillMaxWidth().testTag(OFFICE_ADDRESS))
+                  OutlinedTextField(
+                      value = uiState.office!!.address?.name ?: "",
+                      onValueChange = { if (isOwner) manageOfficeViewModel.onAddressChange(it) },
+                      singleLine = true,
+                      readOnly = true,
+                      label = { Text("Address") },
+                      enabled = isOwner,
+                      modifier = Modifier.fillMaxWidth().testTag(OFFICE_ADDRESS))
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                  Spacer(modifier = Modifier.height(16.dp))
 
-                    Text("Vets in this office:", style = MaterialTheme.typography.titleMedium)
+                  Text("Vets in this office:", style = MaterialTheme.typography.titleMedium)
 
-                    LazyColumn(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .heightIn(max = 300.dp)
-                                .testTag(OFFICE_VET_LIST)) {
-                          items(uiState.office!!.vets) { vetId ->
-                            AuthorName(
-                                vetId,
-                                onClick = {
-                                  focusManager.clearFocus()
-                                  navigationActions.navigateTo(Screen.ViewUser(vetId))
-                                })
-                          }
+                  LazyColumn(
+                      modifier =
+                          Modifier.fillMaxWidth().heightIn(max = 300.dp).testTag(OFFICE_VET_LIST)) {
+                        items(uiState.office!!.vets) { vetId ->
+                          AuthorName(
+                              vetId,
+                              onClick = {
+                                focusManager.clearFocus()
+                                navigationActions.navigateTo(Screen.ViewUser(vetId))
+                              })
                         }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    if (isOwner) {
-                      GenerateCode(
-                          codesViewModel = connectionVm,
-                          snackbarHostState = snackbarHostState,
-                          Modifier.align(Alignment.CenterHorizontally))
-
-                      Spacer(modifier = Modifier.height(8.dp))
-
-                      val scope = rememberCoroutineScope()
-                      Button(
-                          onClick = {
-                            focusManager.clearFocus()
-                            scope.launch { manageOfficeViewModel.updateOffice() }
-                          },
-                          modifier = Modifier.fillMaxWidth().testTag(SAVE_BUTTON),
-                      ) {
-                        Text("Save Changes")
                       }
-                    }
 
-                    OutlinedButton(
-                        onClick = { showLeaveDialog = true },
-                        colors =
-                            ButtonDefaults.outlinedButtonColors(contentColor = StatusColors().spam),
-                        border = BorderStroke(1.dp, StatusColors().spam),
-                        modifier = Modifier.fillMaxWidth().testTag(LEAVE_OFFICE_BUTTON)) {
-                          Text("Leave My Office")
-                        }
+                  Spacer(modifier = Modifier.height(16.dp))
 
-                    if (showLeaveDialog) {
-                      AlertDialog(
-                          onDismissRequest = { showLeaveDialog = false },
-                          title = { Text("Leave Office?") },
-                          text = { Text("Are you sure you want to leave this office?") },
-                          confirmButton = {
-                            TextButton(
-                                onClick = {
-                                  showLeaveDialog = false
-                                  manageOfficeViewModel.leaveOffice(onSuccess = onGoBack)
-                                },
-                                modifier = Modifier.testTag(CONFIRM_LEAVE)) {
-                                  Text("Leave")
-                                }
-                          },
-                          dismissButton = {
-                            TextButton(onClick = { showLeaveDialog = false }) { Text("Cancel") }
-                          })
+                  if (isOwner) {
+                    GenerateCode(
+                        codesViewModel = connectionVm,
+                        snackbarHostState = snackbarHostState,
+                        Modifier.align(Alignment.CenterHorizontally))
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    val scope = rememberCoroutineScope()
+                    Button(
+                        onClick = {
+                          focusManager.clearFocus()
+                          scope.launch { manageOfficeViewModel.updateOffice() }
+                        },
+                        modifier = Modifier.fillMaxWidth().testTag(SAVE_BUTTON),
+                    ) {
+                      Text("Save Changes")
                     }
                   }
-                }
 
+                  OutlinedButton(
+                      onClick = { showLeaveDialog = true },
+                      colors =
+                          ButtonDefaults.outlinedButtonColors(contentColor = StatusColors().spam),
+                      border = BorderStroke(1.dp, StatusColors().spam),
+                      modifier = Modifier.fillMaxWidth().testTag(LEAVE_OFFICE_BUTTON)) {
+                        Text("Leave My Office")
+                      }
+
+                  if (showLeaveDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showLeaveDialog = false },
+                        title = { Text("Leave Office?") },
+                        text = { Text("Are you sure you want to leave this office?") },
+                        confirmButton = {
+                          TextButton(
+                              onClick = {
+                                showLeaveDialog = false
+                                manageOfficeViewModel.leaveOffice(onSuccess = onGoBack)
+                              },
+                              modifier = Modifier.testTag(CONFIRM_LEAVE)) {
+                                Text("Leave")
+                              }
+                        },
+                        dismissButton = {
+                          TextButton(onClick = { showLeaveDialog = false }) { Text("Cancel") }
+                        })
+                  }
+                }
+              }
         }
       }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -1,29 +1,20 @@
 package com.android.agrihealth.ui.office
 
 import android.annotation.SuppressLint
-import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -44,24 +35,11 @@ import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.OFFICE_NAME
 import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.OFFICE_VET_LIST
 import com.android.agrihealth.ui.office.ManageOfficeScreenTestTags.SAVE_BUTTON
 import com.android.agrihealth.ui.profile.CodesViewModel
-import com.android.agrihealth.ui.profile.EditProfileScreenTestTags
-import com.android.agrihealth.ui.profile.EditProfileScreenTexts
 import com.android.agrihealth.ui.profile.GenerateCode
-import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
-import com.android.agrihealth.ui.profile.RemotePhotoDisplay
 import com.android.agrihealth.ui.user.UserViewModel
-import com.android.agrihealth.ui.utils.EditableProfilePicture
 import com.android.agrihealth.ui.utils.EditableProfilePictureWithUI
-import com.android.agrihealth.ui.utils.ImagePickerDialog
 import com.android.agrihealth.ui.utils.PhotoUi
-import com.android.agrihealth.ui.utils.ShowImageCropperDialog
-import com.android.agrihealth.ui.utils.toBitmap
-import com.android.agrihealth.ui.utils.toByteArray
-import com.mr0xf00.easycrop.CropError
-import com.mr0xf00.easycrop.CropResult
-import com.mr0xf00.easycrop.crop
-import com.mr0xf00.easycrop.rememberImageCropper
 import kotlinx.coroutines.launch
 
 object ManageOfficeScreenTestTags {
@@ -74,8 +52,6 @@ object ManageOfficeScreenTestTags {
   const val SAVE_BUTTON = "SaveButton"
   const val LEAVE_OFFICE_BUTTON = "LeaveOfficeButton"
   const val CONFIRM_LEAVE = "ConfirmLeaveOffice"
-  const val PROFILE_PICTURE = "ProfilePicture"
-  const val PROFILE_PICTURE_BUTTON = "ProfilePictuerButton"
 }
 
 @SuppressLint("StateFlowValueCalledInComposition", "SuspiciousIndentation")
@@ -154,6 +130,7 @@ fun ManageOfficeScreen(
                           Text("Join an Office")
                         }
                   } else {
+
                     EditableProfilePictureWithUI(
                       photo = photoUi,
                       isEditable = isOwner,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeScreen.kt
@@ -89,6 +89,8 @@ fun ManageOfficeScreen(
 
   val isOwner = uiState.office?.ownerId == currentUser.uid
 
+  var initialLoad by rememberSaveable { mutableStateOf(true) }
+
   LaunchedEffect(currentUser) { manageOfficeViewModel.loadOffice() }
 
   LaunchedEffect(uiState.error) {
@@ -250,7 +252,7 @@ fun ManageOfficeScreen(
 
 // TODO: Put this in its own file
 @Composable
-fun EditableProfilePicture(
+fun EditableProfilePictureOffice(
   imageViewModel: ImageViewModel,
   profilePictureIsEmpty: Boolean,
   localPhotoUri: Uri?,
@@ -264,7 +266,7 @@ fun EditableProfilePicture(
   ) {
 
 
-    val showRemote = initialLoad && localPhotoUri == null && remotePhotoURL != null
+    val showRemote = initialLoad && localPhotoUri == null
 
     // TODO Make the default profile icon and the actual profile picture the same size
     if (showRemote) {
@@ -330,6 +332,23 @@ fun UploadRemoveOfficePhotoSection(
   }
 
   if (isOwner) {
+    // Camera icon overlay
+    FloatingActionButton(
+      onClick = { handleProfilePictureClick() },
+      modifier = Modifier
+        .size(40.dp)
+        .align(Alignment.BottomEnd)
+        .testTag(EditProfileScreenTestTags.EDIT_PROFILE_PICTURE_BUTTON),
+      containerColor = MaterialTheme.colorScheme.primaryContainer,
+      contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+    ) {
+      Icon(
+        imageVector = if (profilePictureIsEmpty) Icons.Default.CameraAlt else Icons.Default.Clear,
+        contentDescription = "Edit profile picture",
+        modifier = Modifier.size(20.dp)
+      )
+    }
+
     UploadRemovePhotoButton(
         photoAlreadyPicked = photoAlreadyPicked,
         onPhotoPicked = onPhotoPicked,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
@@ -15,24 +15,27 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 data class ManageOfficeUiState(
-  val office: Office? = null,
-  val editableName: String = "",
-  val editableDescription: String = "",
-  val editableAddress: String = "",
-  val isLoading: Boolean = false,
-  val snackMessage: String? = null,
-  val photoBytesToUpload: ByteArray? = null,
-  val removeRemotePhoto: Boolean = false,
+    val office: Office? = null,
+    val editableName: String = "",
+    val editableDescription: String = "",
+    val editableAddress: String = "",
+    val isLoading: Boolean = false,
+    val snackMessage: String? = null,
+    val photoBytesToUpload: ByteArray? = null,
+    val removeRemotePhoto: Boolean = false,
 ) {
-  /** Decides which photo to display depending on the
-   * state of the UI (i.e if a photo has been removed, picked, ...) */
+  /**
+   * Decides which photo to display depending on the state of the UI (i.e if a photo has been
+   * removed, picked, ...)
+   */
   val displayedPhoto: PhotoUi
-    get() = when {
-      photoBytesToUpload != null -> PhotoUi.Local(photoBytesToUpload)
-      removeRemotePhoto -> PhotoUi.Empty
-      office?.photoUrl != null -> PhotoUi.Remote(office.photoUrl)
-      else -> PhotoUi.Empty
-    }
+    get() =
+        when {
+          photoBytesToUpload != null -> PhotoUi.Local(photoBytesToUpload)
+          removeRemotePhoto -> PhotoUi.Empty
+          office?.photoUrl != null -> PhotoUi.Remote(office.photoUrl)
+          else -> PhotoUi.Empty
+        }
 }
 
 class ManageOfficeViewModel(

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
@@ -1,9 +1,7 @@
 package com.android.agrihealth.ui.office
 
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.android.agrihealth.data.model.images.ImageUIState
 import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.data.model.location.Location
 import com.android.agrihealth.data.model.office.Office
@@ -13,7 +11,6 @@ import com.android.agrihealth.ui.loading.withLoadingState
 import com.android.agrihealth.ui.user.UserViewModelContract
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 data class ManageOfficeUiState(
@@ -45,27 +42,27 @@ class ManageOfficeViewModel(
   }
 
   fun loadOffice() {
-      viewModelScope.launch {
-        _uiState.withLoadingState(applyLoading = { s, loading -> s.copy(isLoading = loading) }) {
-          val currentUser = userViewModel.uiState.value.user
-          if (currentUser is Vet && currentUser.officeId != null) {
-            officeRepository.getOffice(currentUser.officeId).fold({ office ->
-              _uiState.value =
-                  _uiState.value.copy(
-                      office = office,
-                      editableName = office.name,
-                      editableDescription = office.description ?: "",
-                      editableAddress = office.address?.toString() ?: "")
-            }) { error ->
-              _uiState.value =
-                  _uiState.value.copy(
-                      snackMessage =
-                          "Couldn't load your office, make sure you are connected to the internet")
-            }
+    viewModelScope.launch {
+      _uiState.withLoadingState(applyLoading = { s, loading -> s.copy(isLoading = loading) }) {
+        val currentUser = userViewModel.uiState.value.user
+        if (currentUser is Vet && currentUser.officeId != null) {
+          officeRepository.getOffice(currentUser.officeId).fold({ office ->
+            _uiState.value =
+                _uiState.value.copy(
+                    office = office,
+                    editableName = office.name,
+                    editableDescription = office.description ?: "",
+                    editableAddress = office.address?.toString() ?: "")
+          }) { error ->
+            _uiState.value =
+                _uiState.value.copy(
+                    snackMessage =
+                        "Couldn't load your office, make sure you are connected to the internet")
           }
         }
       }
     }
+  }
 
   fun onNameChange(value: String) {
     _uiState.value = _uiState.value.copy(editableName = value)
@@ -109,8 +106,7 @@ class ManageOfficeViewModel(
     try {
       val office = _uiState.value.office ?: return
 
-      var newPhotoUrl: String? =
-        if (_uiState.value.removeRemotePhoto) null else office.photoUrl
+      var newPhotoUrl: String? = if (_uiState.value.removeRemotePhoto) null else office.photoUrl
 
       _uiState.value.photoBytes?.let { bytes ->
         newPhotoUrl = imageViewModel.uploadAndWait(bytes)
@@ -131,8 +127,6 @@ class ManageOfficeViewModel(
       onError(e)
     }
   }
-
-
 
   fun setPhoto(photobytes: ByteArray?) {
     _uiState.value = _uiState.value.copy(photoBytes = photobytes, removeRemotePhoto = false)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
@@ -24,6 +24,7 @@ data class ManageOfficeUiState(
     val isLoading: Boolean = false,
     val error: String? = null,
     val photoBytes: ByteArray? = null,
+    val removeRemotePhoto: Boolean = false,
 )
 
 class ManageOfficeViewModel(
@@ -102,10 +103,12 @@ class ManageOfficeViewModel(
     try {
       val office = _uiState.value.office ?: return
 
-      var uploadedPath: String? = null
+      var newPhotoUrl: String? =
+        if (_uiState.value.removeRemotePhoto) null else office.photoUrl
+
       _uiState.value.photoBytes?.let { bytes ->
-        uploadedPath = imageViewModel.uploadAndWait(bytes)
-        _uiState.value = _uiState.value.copy(photoBytes = null)
+        newPhotoUrl = imageViewModel.uploadAndWait(bytes)
+        _uiState.value = _uiState.value.copy(photoBytes = null, removeRemotePhoto = false)
       }
 
       val updatedOffice =
@@ -113,7 +116,7 @@ class ManageOfficeViewModel(
               name = _uiState.value.editableName,
               description = _uiState.value.editableDescription,
               address = newAddress,
-              photoUrl = uploadedPath)
+              photoUrl = newPhotoUrl)
       officeRepository.updateOffice(updatedOffice)
       _uiState.value = _uiState.value.copy(office = updatedOffice)
       onSuccess()
@@ -125,10 +128,10 @@ class ManageOfficeViewModel(
 
 
   fun setPhoto(photobytes: ByteArray?) {
-    _uiState.value = _uiState.value.copy(photoBytes = photobytes)
+    _uiState.value = _uiState.value.copy(photoBytes = photobytes, removeRemotePhoto = false)
   }
 
   fun removePhoto() {
-    _uiState.value = _uiState.value.copy(photoBytes = null)
+    _uiState.value = _uiState.value.copy(photoBytes = null, removeRemotePhoto = true)
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
@@ -123,15 +123,7 @@ class ManageOfficeViewModel(
     }
   }
 
-  suspend fun ImageViewModel.uploadAndWait(uri: Uri): String {
-    upload(uri) // start the upload
-    val result = uiState.first { it is ImageUIState.UploadSuccess || it is ImageUIState.Error }
-    return when (result) {
-      is ImageUIState.UploadSuccess -> result.path
-      is ImageUIState.Error -> throw result.e
-      else -> throw IllegalStateException("Unexpected state")
-    }
-  }
+
 
   fun setPhoto(uri: Uri?) {
     _uiState.value = _uiState.value.copy(photoUri = uri)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
@@ -23,8 +23,7 @@ data class ManageOfficeUiState(
     val editableAddress: String = "",
     val isLoading: Boolean = false,
     val error: String? = null,
-    val photoUri: Uri? = null,
-    val uploadedImagePath: String? = null
+    val photoBytes: ByteArray? = null,
 )
 
 class ManageOfficeViewModel(
@@ -102,11 +101,11 @@ class ManageOfficeViewModel(
   ) {
     try {
       val office = _uiState.value.office ?: return
-      var uploadedPath = _uiState.value.uploadedImagePath
 
-      _uiState.value.photoUri?.let { uri ->
-        uploadedPath = imageViewModel.uploadAndWait(uri)
-        _uiState.value = _uiState.value.copy(uploadedImagePath = uploadedPath, photoUri = null)
+      var uploadedPath: String? = null
+      _uiState.value.photoBytes?.let { bytes ->
+        uploadedPath = imageViewModel.uploadAndWait(bytes)
+        _uiState.value = _uiState.value.copy(photoBytes = null)
       }
 
       val updatedOffice =
@@ -125,11 +124,11 @@ class ManageOfficeViewModel(
 
 
 
-  fun setPhoto(uri: Uri?) {
-    _uiState.value = _uiState.value.copy(photoUri = uri)
+  fun setPhoto(photobytes: ByteArray?) {
+    _uiState.value = _uiState.value.copy(photoBytes = photobytes)
   }
 
   fun removePhoto() {
-    _uiState.value = _uiState.value.copy(photoUri = null)
+    _uiState.value = _uiState.value.copy(photoBytes = null)
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -43,7 +43,6 @@ import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
 import com.android.agrihealth.ui.utils.EditableProfilePictureWithUI
-import com.android.agrihealth.ui.utils.PhotoUi
 import kotlinx.coroutines.launch
 
 enum class CodeType {
@@ -151,18 +150,6 @@ fun EditProfileScreen(
   var removeRemotePhoto by rememberSaveable { mutableStateOf(false) }
   var localPhotoByteArray: ByteArray? by rememberSaveable { mutableStateOf(null) }
 
-  // Decide what to display for the profile picture
-  val photoUi by
-      remember(user.photoURL, localPhotoByteArray, removeRemotePhoto) {
-        mutableStateOf(
-            when {
-              localPhotoByteArray != null -> PhotoUi.Local(localPhotoByteArray!!)
-              removeRemotePhoto -> PhotoUi.Empty
-              user.photoURL != null -> PhotoUi.Remote(user.photoURL!!)
-              else -> PhotoUi.Empty
-            })
-      }
-
   // TODO: Refactor this so each UI component are in their own composable
   Scaffold(
       topBar = {
@@ -194,7 +181,11 @@ fun EditProfileScreen(
               HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
 
               EditableProfilePictureWithUI(
-                  photo = photoUi,
+                  photo = editProfileViewModel.choosePhotoToDisplay(
+                    remotePhotoURL = user.photoURL,
+                    localPhotoBytes = localPhotoByteArray,
+                    removeRemotePhoto = removeRemotePhoto
+                  ),
                   isEditable = true,
                   imageViewModel = imageViewModel,
                   onPhotoPicked = { bytes ->

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -69,21 +69,9 @@ import com.mr0xf00.easycrop.CropError
 import com.mr0xf00.easycrop.CropResult
 import com.mr0xf00.easycrop.CropState
 import com.mr0xf00.easycrop.CropperStyle
-import com.mr0xf00.easycrop.ImageCropper
-import com.mr0xf00.easycrop.LocalCropperStyle
 import com.mr0xf00.easycrop.crop
-import com.mr0xf00.easycrop.flipHorizontal
-import com.mr0xf00.easycrop.flipVertical
-import com.mr0xf00.easycrop.images.ImageSrc
 import com.mr0xf00.easycrop.rememberImageCropper
-import com.mr0xf00.easycrop.rotLeft
-import com.mr0xf00.easycrop.rotRight
-import com.mr0xf00.easycrop.ui.AspectSelectionMenu
-import com.mr0xf00.easycrop.ui.ButtonsBar
-import com.mr0xf00.easycrop.ui.CropperControls
 import com.mr0xf00.easycrop.ui.ImageCropperDialog
-import com.mr0xf00.easycrop.ui.LocalVerticalControls
-import com.mr0xf00.easycrop.ui.ShapeSelectionMenu
 import kotlinx.coroutines.launch
 
 enum class CodeType {
@@ -484,6 +472,7 @@ fun EditProfileScreen(
     ImageCropperDialog(
       state = cropState,
       topBar = { ImageCropperDialogControls(cropState) },
+      cropControls = {},
       style = CropperStyle(
         autoZoom = true,
         guidelines = null,
@@ -533,20 +522,6 @@ fun ImageCropperDialogControls(state: CropState) {
     }
   )
 }
-
-@Composable
-private fun BoxScope.DefaultControls(state: CropState) {
-  val verticalControls =
-    LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-  CropperControls(
-    isVertical = verticalControls,
-    state = state,
-    modifier = Modifier
-      .align(if (!verticalControls) Alignment.BottomCenter else Alignment.CenterEnd)
-      .padding(12.dp),
-  )
-}
-
 
 
 // Created with the help of an LLM

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -179,16 +179,15 @@ fun EditProfileScreen(
               HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
 
               EditableProfilePictureWithImageCropper(
-                  photo = editProfileViewModel.choosePhotoToDisplay(
-                    remotePhotoURL = user.photoURL,
-                    localPhotoBytes = localPhotoByteArray,
-                    removeRemotePhoto = removeRemotePhoto
-                  ),
+                  photo =
+                      editProfileViewModel.choosePhotoToDisplay(
+                          remotePhotoURL = user.photoURL,
+                          localPhotoBytes = localPhotoByteArray,
+                          removeRemotePhoto = removeRemotePhoto),
                   isEditable = true,
                   imageViewModel = imageViewModel,
                   onPhotoPicked = { bytes ->
-                    localPhotoByteArray =
-                        bytes
+                    localPhotoByteArray = bytes
                     removeRemotePhoto = false
                   },
                   onPhotoRemoved = {
@@ -387,7 +386,6 @@ fun EditProfileScreen(
                   }
             }
       }
-
 }
 
 /*

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -1,10 +1,6 @@
 package com.android.agrihealth.ui.profile
 
-import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.ImageDecoder
 import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
@@ -18,20 +14,14 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material3.*
-import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -59,18 +49,11 @@ import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
 import com.android.agrihealth.ui.utils.ImagePickerDialog
-import com.mr0xf00.easycrop.AspectRatio
-import com.mr0xf00.easycrop.CircleCropShape
 import com.mr0xf00.easycrop.CropError
 import com.mr0xf00.easycrop.CropResult
-import com.mr0xf00.easycrop.CropState
-import com.mr0xf00.easycrop.CropperStyle
 import com.mr0xf00.easycrop.crop
 import com.mr0xf00.easycrop.rememberImageCropper
-import com.mr0xf00.easycrop.ui.ImageCropperDialog
 import kotlinx.coroutines.launch
-import java.io.ByteArrayOutputStream
-import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.ViewModelProvider
 import com.android.agrihealth.ui.report.AddReportDialogTexts
@@ -79,7 +62,6 @@ import com.android.agrihealth.ui.report.AddReportScreenTestTags
 import com.android.agrihealth.ui.utils.ShowImageCropperDialog
 import com.android.agrihealth.ui.utils.toBitmap
 import com.android.agrihealth.ui.utils.toByteArray
-import com.mr0xf00.easycrop.ImageCropper
 
 enum class CodeType {
   FARMER,
@@ -257,7 +239,7 @@ fun EditProfileScreen(
             verticalArrangement = Arrangement.Top) {
               HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
 
-            EditableProfilePicture(
+            EditProfile_EditableProfilePicture(
                 imageViewModel = imageViewModel,
                 localPhotoByteArray = localPhotoByteArray,
                 remotePhotoURL = effectiveRemoteUrl,
@@ -513,7 +495,7 @@ fun ErrorDialog(errorMessage: String?, onDismiss: () -> Unit) {
 
 // TODO: Put this in its own file
 @Composable
-fun EditableProfilePicture(
+fun EditProfile_EditableProfilePicture(
   imageViewModel: ImageViewModel,
   profilePictureIsEmpty: Boolean,
   localPhotoByteArray: ByteArray?,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -125,8 +125,8 @@ fun EditProfileScreen(
 ) {
   val focusManager = LocalFocusManager.current
 
-  val connectionRepository = rememberSaveable { ConnectionRepository(connectionType = "") }
-  val codesViewModel = rememberSaveable { CodesViewModel(userViewModel, connectionRepository) }
+  val connectionRepository = remember { ConnectionRepository(connectionType = "") }
+  val codesViewModel = remember { CodesViewModel(userViewModel, connectionRepository) }
 
   val uiState by userViewModel.uiState.collectAsState()
   val user = uiState.user
@@ -169,7 +169,7 @@ fun EditProfileScreen(
 
   val isOwner = manageOfficeVm.uiState.collectAsState().value.office?.ownerId == user.uid
 
-  val snackbarHostState = rememberSaveable { SnackbarHostState() }
+  val snackbarHostState = remember { SnackbarHostState() }
 
   // Local mutable states
   var firstname by rememberSaveable { mutableStateOf(user.firstname) }
@@ -193,7 +193,7 @@ fun EditProfileScreen(
   val context = LocalContext.current
   val croppingIsOngoing = imageCropper.cropState != null
   var chosenPhoto : ByteArray? by rememberSaveable {mutableStateOf(null)}
-  val launchImageCropper: (Uri) -> Unit = rememberSaveable {
+  val launchImageCropper: (Uri) -> Unit = remember {
     { uri: Uri ->
       scope.launch {
         val bitmap = uri.toBitmap(context).asImageBitmap()

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ContentCopy
@@ -52,7 +51,6 @@ import com.android.agrihealth.ui.navigation.NavigationTestTags
 import com.android.agrihealth.ui.navigation.NavigationTestTags.GO_BACK_BUTTON
 import com.android.agrihealth.ui.office.ManageOfficeViewModel
 import com.android.agrihealth.ui.profile.EditProfileScreenTestTags.PASSWORD_BUTTON
-import com.android.agrihealth.ui.profile.ProfileScreenTestTags.PROFILE_IMAGE
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
@@ -497,21 +495,7 @@ fun ShowImageCropperDialog(imageCropper: ImageCropper) {
 
   // Setting this once
   LaunchedEffect(cropState) {
-    // Force the region to be a square instead of a rectangle
-    val region = cropState.region
-    val size = minOf(region.width, region.height)
-    val centerX = region.center.x
-    val centerY = region.center.y
-
-    cropState.region = Rect(
-      left = centerX - size / 2f,
-      top = centerY - size / 2f,
-      right = centerX + size / 2f,
-      bottom = centerY + size / 2f
-    )
-
-    cropState.aspectLock = true
-    cropState.shape = CircleCropShape
+    setImageCropperShapeCircle(cropState)
   }
 
   ImageCropperDialog(
@@ -542,6 +526,7 @@ fun EditableProfilePicture(
     var initialLoad by rememberSaveable { mutableStateOf(true) }
     val showRemote = initialLoad && remotePhotoURL != null
 
+    // TODO Make the default profile icon and the actual profile picture the same size
     if (showRemote) {
       RemotePhotoDisplay(
         photoURL = remotePhotoURL,
@@ -556,17 +541,6 @@ fun EditableProfilePicture(
         showPlaceHolder = true,
       )
     }
-
-//    Icon(
-//      imageVector = Icons.Default.AccountCircle,
-//      contentDescription = "Profile Picture",
-//      modifier = Modifier
-//        .size(120.dp)
-//        .clip(CircleShape)
-//        .testTag(PROFILE_IMAGE)
-//        .clickable { handleProfilePictureClick() },
-//      tint = MaterialTheme.colorScheme.primary,
-//    )
 
     // Camera icon overlay
     FloatingActionButton(
@@ -587,9 +561,29 @@ fun EditableProfilePicture(
   }
 }
 
+private fun setImageCropperShapeCircle(state: CropState) {
+  state.reset()
+  // Force the region to be square
+  val currentRegion = state.region
+  val size = minOf(currentRegion.width, currentRegion.height)
+  val centerX = currentRegion.center.x
+  val centerY = currentRegion.center.y
+
+  state.region = Rect(
+    left = centerX - size / 2f,
+    top = centerY - size / 2f,
+    right = centerX + size / 2f,
+    bottom = centerY + size / 2f
+  )
+
+  state.aspectLock = true
+  state.shape = CircleCropShape
+}
+
+// Replacing the default topbar of the image cropper (specifically change the reset button)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ImageCropperCustomTopBar(state: CropState) {
+private fun ImageCropperCustomTopBar(state: CropState) {
   TopAppBar(title = {},
     navigationIcon = {
       IconButton(onClick = { state.done(accept = false) }) {
@@ -598,22 +592,7 @@ fun ImageCropperCustomTopBar(state: CropState) {
     },
     actions = {
       IconButton(onClick = {
-        state.reset()
-        // Force the region to be square
-        val currentRegion = state.region
-        val size = minOf(currentRegion.width, currentRegion.height)
-        val centerX = currentRegion.center.x
-        val centerY = currentRegion.center.y
-
-        state.region = Rect(
-          left = centerX - size / 2f,
-          top = centerY - size / 2f,
-          right = centerX + size / 2f,
-          bottom = centerY + size / 2f
-        )
-
-        state.aspectLock = true
-        state.shape = CircleCropShape
+        setImageCropperShapeCircle(state)
       }) {
         Icon(Icons.Default.Replay, contentDescription = "Restore")
       }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -224,12 +224,6 @@ fun EditProfileScreen(
     }
   }
 
-  // Reset the "initialLoad" flag when a different user is loaded
-  LaunchedEffect(user.uid) {
-    initialLoad = true
-    localPhotoByteArray = null
-  }
-
 
   // TODO: Refactor this so each UI component are in their own composable
   Scaffold(

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -557,16 +557,16 @@ fun EditableProfilePicture(
       )
     }
 
-    Icon(
-      imageVector = Icons.Default.AccountCircle,
-      contentDescription = "Profile Picture",
-      modifier = Modifier
-        .size(120.dp)
-        .clip(CircleShape)
-        .testTag(PROFILE_IMAGE)
-        .clickable { handleProfilePictureClick() },
-      tint = MaterialTheme.colorScheme.primary,
-    )
+//    Icon(
+//      imageVector = Icons.Default.AccountCircle,
+//      contentDescription = "Profile Picture",
+//      modifier = Modifier
+//        .size(120.dp)
+//        .clip(CircleShape)
+//        .testTag(PROFILE_IMAGE)
+//        .clickable { handleProfilePictureClick() },
+//      tint = MaterialTheme.colorScheme.primary,
+//    )
 
     // Camera icon overlay
     FloatingActionButton(

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.agrihealth.core.design.theme.AgriHealthAppTheme
 import com.android.agrihealth.data.model.connection.ConnectionRepository
@@ -41,10 +42,9 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
-import kotlinx.coroutines.launch
-import androidx.lifecycle.ViewModelProvider
 import com.android.agrihealth.ui.utils.EditableProfilePictureWithUI
 import com.android.agrihealth.ui.utils.PhotoUi
+import kotlinx.coroutines.launch
 
 enum class CodeType {
   FARMER,
@@ -75,8 +75,6 @@ object EditProfileScreenTestTags {
 
   fun dropdownElementTag(type: String) = "ACTIVE_CODE_ELEMENT_$type"
 }
-
-
 
 // TODO Make screen go back to view profile when saving changes
 @OptIn(ExperimentalMaterial3Api::class)
@@ -125,7 +123,9 @@ fun EditProfileScreen(
           factory =
               object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                  return EditProfileViewModel(officeRepository = OfficeRepositoryProvider.get(), imageViewModel = imageViewModel)
+                  return EditProfileViewModel(
+                      officeRepository = OfficeRepositoryProvider.get(),
+                      imageViewModel = imageViewModel)
                       as T
                 }
               })
@@ -152,17 +152,16 @@ fun EditProfileScreen(
   var localPhotoByteArray: ByteArray? by rememberSaveable { mutableStateOf(null) }
 
   // Decide what to display for the profile picture
-  val photoUi by remember(user.photoURL, localPhotoByteArray, removeRemotePhoto) {
-    mutableStateOf(
-      when {
-        localPhotoByteArray != null -> PhotoUi.Local(localPhotoByteArray!!)
-        removeRemotePhoto -> PhotoUi.Empty
-        user.photoURL != null -> PhotoUi.Remote(user.photoURL!!)
-        else -> PhotoUi.Empty
+  val photoUi by
+      remember(user.photoURL, localPhotoByteArray, removeRemotePhoto) {
+        mutableStateOf(
+            when {
+              localPhotoByteArray != null -> PhotoUi.Local(localPhotoByteArray!!)
+              removeRemotePhoto -> PhotoUi.Empty
+              user.photoURL != null -> PhotoUi.Remote(user.photoURL!!)
+              else -> PhotoUi.Empty
+            })
       }
-    )
-  }
-
 
   // TODO: Refactor this so each UI component are in their own composable
   Scaffold(
@@ -187,27 +186,26 @@ fun EditProfileScreen(
         Column(
             modifier =
                 Modifier.padding(innerPadding)
-                  .padding(16.dp)
-                  .fillMaxSize()
-                  .verticalScroll(rememberScrollState()),
+                    .padding(16.dp)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Top) {
               HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
 
-          EditableProfilePictureWithUI(
-            photo = photoUi,
-            isEditable = true,
-            imageViewModel = imageViewModel,
-            onPhotoPicked = { bytes ->
-              localPhotoByteArray = bytes   // TODO Replace this with something like viewModel.setPhoto(bytes)
-              removeRemotePhoto = false
-            },
-            onPhotoRemoved = {
-              localPhotoByteArray = null
-              removeRemotePhoto = true
-            }
-          )
-
+              EditableProfilePictureWithUI(
+                  photo = photoUi,
+                  isEditable = true,
+                  imageViewModel = imageViewModel,
+                  onPhotoPicked = { bytes ->
+                    localPhotoByteArray =
+                        bytes // TODO Replace this with something like viewModel.setPhoto(bytes)
+                    removeRemotePhoto = false
+                  },
+                  onPhotoRemoved = {
+                    localPhotoByteArray = null
+                    removeRemotePhoto = true
+                  })
 
               Spacer(modifier = Modifier.height(24.dp))
 
@@ -387,7 +385,7 @@ fun EditProfileScreen(
                               description = description,
                               collected = collected,
                               photoByteArray = localPhotoByteArray,
-                            removeRemotePhoto = removeRemotePhoto)
+                              removeRemotePhoto = removeRemotePhoto)
                       updatedUser?.let {
                         onSave(it)
                         removeRemotePhoto = false
@@ -401,7 +399,6 @@ fun EditProfileScreen(
             }
       }
 }
-
 
 /*
 @Preview(showBackground = true)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -74,7 +74,6 @@ object EditProfileScreenTestTags {
   fun dropdownElementTag(type: String) = "ACTIVE_CODE_ELEMENT_$type"
 }
 
-// TODO Make screen go back to view profile when saving changes
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditProfileScreen(
@@ -150,7 +149,6 @@ fun EditProfileScreen(
   var removeRemotePhoto by rememberSaveable { mutableStateOf(false) }
   var localPhotoByteArray: ByteArray? by rememberSaveable { mutableStateOf(null) }
 
-  // TODO: Refactor this so each UI component are in their own composable
   Scaffold(
       topBar = {
         TopAppBar(

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -1,18 +1,14 @@
 package com.android.agrihealth.ui.profile
 
-import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -21,10 +17,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
@@ -48,22 +41,10 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
-import com.android.agrihealth.ui.utils.ImagePickerDialog
-import com.mr0xf00.easycrop.CropError
-import com.mr0xf00.easycrop.CropResult
-import com.mr0xf00.easycrop.crop
-import com.mr0xf00.easycrop.rememberImageCropper
 import kotlinx.coroutines.launch
-import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.ViewModelProvider
-import com.android.agrihealth.ui.report.AddReportDialogTexts
-import com.android.agrihealth.ui.report.AddReportFeedbackTexts
-import com.android.agrihealth.ui.report.AddReportScreenTestTags
 import com.android.agrihealth.ui.utils.EditableProfilePictureWithUI
 import com.android.agrihealth.ui.utils.PhotoUi
-import com.android.agrihealth.ui.utils.ShowImageCropperDialog
-import com.android.agrihealth.ui.utils.toBitmap
-import com.android.agrihealth.ui.utils.toByteArray
 
 enum class CodeType {
   FARMER,
@@ -95,13 +76,9 @@ object EditProfileScreenTestTags {
   fun dropdownElementTag(type: String) = "ACTIVE_CODE_ELEMENT_$type"
 }
 
-object EditProfileScreenTexts {
-  const val DIALOG_LOADING_ERROR = "The supplied image is invalid, not supported, or you don't have the required permissions to read it..."
-  const val DIALOG_SAVING_ERROR = "The result could not be saved. The selected area is likely to big, try selecting a smaller area..."
-}
+
 
 // TODO Make screen go back to view profile when saving changes
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditProfileScreen(
@@ -222,7 +199,7 @@ fun EditProfileScreen(
             isEditable = true,
             imageViewModel = imageViewModel,
             onPhotoPicked = { bytes ->
-              localPhotoByteArray = bytes
+              localPhotoByteArray = bytes   // TODO Replace this with something like viewModel.setPhoto(bytes)
               removeRemotePhoto = false
             },
             onPhotoRemoved = {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -76,6 +76,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.android.agrihealth.ui.report.AddReportDialogTexts
 import com.android.agrihealth.ui.report.AddReportFeedbackTexts
 import com.android.agrihealth.ui.report.AddReportScreenTestTags
+import com.android.agrihealth.ui.utils.ShowImageCropperDialog
 import com.mr0xf00.easycrop.ImageCropper
 
 enum class CodeType {
@@ -509,29 +510,6 @@ fun ErrorDialog(errorMessage: String?, onDismiss: () -> Unit) {
 
 // TODO: Put this in its own file
 @Composable
-fun ShowImageCropperDialog(imageCropper: ImageCropper) {
-  val cropState = imageCropper.cropState!!
-
-  // Setting this once
-  LaunchedEffect(cropState) {
-    setImageCropperShapeCircle(cropState)
-  }
-
-  ImageCropperDialog(
-    state = cropState,
-    topBar = { ImageCropperCustomTopBar(cropState) },
-    cropControls = {},
-    style = CropperStyle(
-      autoZoom = true,
-      guidelines = null,
-      shapes = listOf(CircleCropShape),
-      overlay = Color.Black.copy(alpha = .7f),
-      aspects = listOf(AspectRatio(1, 1))
-    ))
-}
-
-// TODO: Put this in its own file
-@Composable
 fun EditableProfilePicture(
   imageViewModel: ImageViewModel,
   profilePictureIsEmpty: Boolean,
@@ -583,48 +561,6 @@ fun EditableProfilePicture(
   }
 }
 
-private fun setImageCropperShapeCircle(state: CropState) {
-  state.reset()
-  // Force the region to be square
-  val currentRegion = state.region
-  val size = minOf(currentRegion.width, currentRegion.height)
-  val centerX = currentRegion.center.x
-  val centerY = currentRegion.center.y
-
-  state.region = Rect(
-    left = centerX - size / 2f,
-    top = centerY - size / 2f,
-    right = centerX + size / 2f,
-    bottom = centerY + size / 2f
-  )
-
-  state.aspectLock = true
-  state.shape = CircleCropShape
-}
-
-// Replacing the default topbar of the image cropper (specifically change the reset button)
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ImageCropperCustomTopBar(state: CropState) {
-  TopAppBar(title = {},
-    navigationIcon = {
-      IconButton(onClick = { state.done(accept = false) }) {
-        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Cancel cropping")
-      }
-    },
-    actions = {
-      IconButton(onClick = {
-        setImageCropperShapeCircle(state)
-      }) {
-        Icon(Icons.Default.Replay, contentDescription = "Restore")
-      }
-      IconButton(onClick = { state.done(accept = true) }, enabled = !state.accepted) {
-        Icon(Icons.Default.Done, contentDescription = "Submit")
-      }
-    },
-    colors = topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
-  )
-}
 
 // Created with the help of an LLM
 private fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG, quality: Int = 100): ByteArray {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -69,7 +69,6 @@ object EditProfileScreenTestTags {
   const val SAVE_BUTTON = "SaveButton"
   const val PASSWORD_BUTTON = "PasswordButton"
   const val COPY_CODE_BUTTON = "CopyActiveCodeListElementButton"
-  const val EDIT_PROFILE_PICTURE_BUTTON = "EditProfilePictureButton"
 
   fun dropdownTag(type: String) = "ACTIVE_CODES_DROPDOWN_$type"
 
@@ -136,6 +135,7 @@ fun EditProfileScreen(
 
   val snackbarHostState = remember { SnackbarHostState() }
 
+  // TODO Create a uiState in the viewModel to avoid having to remember all this
   // Local mutable states
   var firstname by rememberSaveable { mutableStateOf(user.firstname) }
   var lastname by rememberSaveable { mutableStateOf(user.lastname) }
@@ -199,7 +199,7 @@ fun EditProfileScreen(
                   imageViewModel = imageViewModel,
                   onPhotoPicked = { bytes ->
                     localPhotoByteArray =
-                        bytes // TODO Replace this with something like viewModel.setPhoto(bytes)
+                        bytes
                     removeRemotePhoto = false
                   },
                   onPhotoRemoved = {
@@ -398,6 +398,7 @@ fun EditProfileScreen(
                   }
             }
       }
+
 }
 
 /*

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -77,6 +77,8 @@ import com.android.agrihealth.ui.report.AddReportDialogTexts
 import com.android.agrihealth.ui.report.AddReportFeedbackTexts
 import com.android.agrihealth.ui.report.AddReportScreenTestTags
 import com.android.agrihealth.ui.utils.ShowImageCropperDialog
+import com.android.agrihealth.ui.utils.toBitmap
+import com.android.agrihealth.ui.utils.toByteArray
 import com.mr0xf00.easycrop.ImageCropper
 
 enum class CodeType {
@@ -113,6 +115,8 @@ object EditProfileScreenTexts {
   const val DIALOG_LOADING_ERROR = "The supplied image is invalid, not supported, or you don't have the required permissions to read it..."
   const val DIALOG_SAVING_ERROR = "The result could not be saved. The selected area is likely to big, try selecting a smaller area..."
 }
+
+// TODO Make screen go back to view profile when saving changes
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -200,6 +204,8 @@ fun EditProfileScreen(
   val context = LocalContext.current
   val croppingIsOngoing = imageCropper.cropState != null
   var initialLoad by rememberSaveable { mutableStateOf(true) }
+
+  // TODO: Put launcher in PhotoCropper
   val launchImageCropper: (Uri) -> Unit = remember {
     { uri: Uri ->
       scope.launch {
@@ -562,24 +568,6 @@ fun EditableProfilePicture(
 }
 
 
-// Created with the help of an LLM
-private fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG, quality: Int = 100): ByteArray {
-  val bitmap = this.asAndroidBitmap()
-  val outputStream = ByteArrayOutputStream()
-  bitmap.compress(format, quality, outputStream)
-  return outputStream.toByteArray()
-}
-
-// Created with the help of an LLM
-private fun Uri.toBitmap(context: Context): Bitmap {
-  val source = ImageDecoder.createSource(context.contentResolver, this)
-
-  // Forcing to use software allocator (instead of hardware) and forcing bitmap to be mutable to prevent issues when cropping the photo
-  return ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
-    decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
-    decoder.isMutableRequired = true
-  }
-}
 
 /*
 @Preview(showBackground = true)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -158,7 +158,7 @@ fun EditProfileScreen(
           factory =
               object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                  return EditProfileViewModel(officeRepository = OfficeRepositoryProvider.get())
+                  return EditProfileViewModel(officeRepository = OfficeRepositoryProvider.get(), imageViewModel = imageViewModel)
                       as T
                 }
               })
@@ -213,6 +213,7 @@ fun EditProfileScreen(
   }
 
 
+  // TODO: Refactor this so each UI component are in their own composable
   Scaffold(
       topBar = {
         TopAppBar(
@@ -246,7 +247,7 @@ fun EditProfileScreen(
                 imageViewModel = imageViewModel,
                 profilePictureIsEmpty = chosenPhoto == null,
                 localPhotoByteArray = chosenPhoto,
-                remotePhotoURL = null,   // TODO Change this
+                remotePhotoURL = user.photoURL,
                 handleProfilePictureClick = {
                   if (chosenPhoto == null) {
                     showPhotoPickerDialog = true
@@ -433,7 +434,8 @@ fun EditProfileScreen(
                               pickedLocation = pickedLocation,
                               selectedDefaultOffice = selectedDefaultOffice,
                               description = description,
-                              collected = collected)
+                              collected = collected,
+                              photoByteArray = chosenPhoto)
                       updatedUser?.let { onSave(it) }
                     }
                   },

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -138,7 +138,6 @@ fun EditProfileScreen(
   val user = uiState.user
   val userRole = user.role
   val currentUser = user
-  val displayRemotePhoto: Boolean by rememberSaveable { mutableStateOf(true) }
 
   LaunchedEffect(user) {
     if (currentUser is Vet) {
@@ -148,8 +147,6 @@ fun EditProfileScreen(
 
   val farmerCodes by codesViewModel.farmerCodes.collectAsState()
   val vetCodes by codesViewModel.vetCodes.collectAsState()
-
-  val imageViewModel: ImageViewModel = viewModel()
 
   val createManageOfficeViewModel =
       object : ViewModelProvider.Factory {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -42,7 +42,7 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
-import com.android.agrihealth.ui.utils.EditableProfilePictureWithUI
+import com.android.agrihealth.ui.utils.EditableProfilePictureWithImageCropper
 import kotlinx.coroutines.launch
 
 enum class CodeType {
@@ -178,7 +178,7 @@ fun EditProfileScreen(
             verticalArrangement = Arrangement.Top) {
               HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
 
-              EditableProfilePictureWithUI(
+              EditableProfilePictureWithImageCropper(
                   photo = editProfileViewModel.choosePhotoToDisplay(
                     remotePhotoURL = user.photoURL,
                     localPhotoBytes = localPhotoByteArray,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -135,8 +135,6 @@ fun EditProfileScreen(
   val currentUser = user
   val displayRemotePhoto: Boolean by rememberSaveable { mutableStateOf(true) }
 
-  Log.d("EditProfileScreen", "photoRUL = " + user.photoURL.toString())
-
   LaunchedEffect(user) {
     if (currentUser is Vet) {
       codesViewModel.loadActiveCodesForVet(currentUser)
@@ -509,7 +507,7 @@ fun ErrorDialog(errorMessage: String?, onDismiss: () -> Unit) {
     modifier = Modifier.testTag(AddReportScreenTestTags.DIALOG_FAILURE))
 }
 
-
+// TODO: Put this in its own file
 @Composable
 fun ShowImageCropperDialog(imageCropper: ImageCropper) {
   val cropState = imageCropper.cropState!!
@@ -532,7 +530,7 @@ fun ShowImageCropperDialog(imageCropper: ImageCropper) {
     ))
 }
 
-
+// TODO: Put this in its own file
 @Composable
 fun EditableProfilePicture(
   imageViewModel: ImageViewModel,
@@ -547,21 +545,18 @@ fun EditableProfilePicture(
     contentAlignment = Alignment.Center,
   ) {
 
-    //var initialLoad by rememberSaveable { mutableStateOf(true) }
-    //val showRemote = initialLoad && remotePhotoURL != null
+
     val showRemote = initialLoad && localPhotoByteArray == null && remotePhotoURL != null
-    Log.d("EditProfileScreen", "remotePhotoURL = $remotePhotoURL")
 
     // TODO Make the default profile icon and the actual profile picture the same size
     if (showRemote) {
       RemotePhotoDisplay(
         photoURL = remotePhotoURL,
         imageViewModel = imageViewModel,
-        modifier = Modifier.size(120.dp).clip(CircleShape),
+        modifier = Modifier.size(120.dp).clip(CircleShape),   // TODO Create a component for Profile Picture
         contentDescription = "Office photo",
         showPlaceHolder = true)
     } else {
-      Log.d("EditProfile", "localPhotoByteArray is null?: " + (localPhotoByteArray == null).toString())
       LocalPhotoDisplay(
         photoByteArray = localPhotoByteArray,
         modifier = Modifier.size(120.dp).clip(CircleShape),

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.android.agrihealth.ui.profile
 
+import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
@@ -11,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -42,6 +44,8 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
+import com.android.agrihealth.ui.utils.ImagePickerDialog
+import com.mr0xf00.easycrop.rememberImageCropper
 
 enum class CodeType {
   FARMER,
@@ -66,6 +70,7 @@ object EditProfileScreenTestTags {
   const val SAVE_BUTTON = "SaveButton"
   const val PASSWORD_BUTTON = "PasswordButton"
   const val COPY_CODE_BUTTON = "CopyActiveCodeListElementButton"
+  const val EDIT_PROFILE_PICTURE_BUTTON = "EditProfilePictureButton"
 
   fun dropdownTag(type: String) = "ACTIVE_CODES_DROPDOWN_$type"
 
@@ -125,6 +130,11 @@ fun EditProfileScreen(
   var expandedVetDropdown by remember { mutableStateOf(false) }
   var collected by remember { mutableStateOf(user.collected) }
 
+  var showPhotoPickerDialog by remember { mutableStateOf(false) }
+  var showPhotoCropper by remember { mutableStateOf(false) }
+  var chosenUri : Uri? by remember {mutableStateOf(null)}
+  val imageCropper = rememberImageCropper()
+
   Scaffold(
       topBar = {
         TopAppBar(
@@ -152,12 +162,37 @@ fun EditProfileScreen(
             verticalArrangement = Arrangement.Top) {
               HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
 
-              // Profile Image Placeholder
+          Box(
+            modifier = Modifier.size(120.dp),
+            contentAlignment = Alignment.Center
+          ) {
+            Icon(
+              imageVector = Icons.Default.AccountCircle,
+              contentDescription = "Profile Picture",
+              modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .testTag(PROFILE_IMAGE),
+              tint = MaterialTheme.colorScheme.primary
+            )
+
+            // Camera icon overlay
+            FloatingActionButton(
+              onClick = { showPhotoPickerDialog = true },
+              modifier = Modifier
+                .size(40.dp)
+                .align(Alignment.BottomEnd)
+                .testTag(EditProfileScreenTestTags.EDIT_PROFILE_PICTURE_BUTTON),
+              containerColor = MaterialTheme.colorScheme.primaryContainer,
+              contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            ) {
               Icon(
-                  imageVector = Icons.Default.AccountCircle,
-                  contentDescription = "Profile Picture",
-                  modifier = Modifier.size(120.dp).clip(CircleShape).testTag(PROFILE_IMAGE),
-                  tint = MaterialTheme.colorScheme.primary)
+                imageVector = Icons.Default.CameraAlt,
+                contentDescription = "Edit profile picture",
+                modifier = Modifier.size(20.dp)
+              )
+            }
+          }
 
               Spacer(modifier = Modifier.height(24.dp))
 
@@ -347,6 +382,14 @@ fun EditProfileScreen(
                   }
             }
       }
+
+  if (showPhotoPickerDialog) {
+    ImagePickerDialog({showPhotoPickerDialog = false}, { uri -> chosenUri = uri; showPhotoCropper = true })
+  }
+
+  if (showPhotoCropper) {
+
+  }
 }
 
 /*

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileScreen.kt
@@ -133,7 +133,6 @@ fun EditProfileScreen(
 
   val snackbarHostState = remember { SnackbarHostState() }
 
-  // TODO Create a uiState in the viewModel to avoid having to remember all this
   // Local mutable states
   var firstname by rememberSaveable { mutableStateOf(user.firstname) }
   var lastname by rememberSaveable { mutableStateOf(user.lastname) }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -1,13 +1,17 @@
 package com.android.agrihealth.ui.profile
 
 import androidx.lifecycle.ViewModel
+import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.data.model.location.Location
 import com.android.agrihealth.data.model.office.OfficeRepository
 import com.android.agrihealth.data.model.user.Farmer
 import com.android.agrihealth.data.model.user.User
 import com.android.agrihealth.data.model.user.Vet
 
-class EditProfileViewModel(private val officeRepository: OfficeRepository) : ViewModel() {
+class EditProfileViewModel(
+  private val officeRepository: OfficeRepository,
+  private val imageViewModel: ImageViewModel
+) : ViewModel() {
 
   suspend fun saveProfileChanges(
       user: User,
@@ -16,7 +20,8 @@ class EditProfileViewModel(private val officeRepository: OfficeRepository) : Vie
       pickedLocation: Location?,
       selectedDefaultOffice: String?,
       description: String,
-      collected: Boolean
+      collected: Boolean,
+      photoByteArray: ByteArray?
   ): User? {
     val updatedDescription = description.ifBlank { null }
 
@@ -30,6 +35,17 @@ class EditProfileViewModel(private val officeRepository: OfficeRepository) : Vie
       }
     }
 
+    var uploadedPhotoURL: String? = null
+    if (photoByteArray != null) {
+      try {
+        uploadedPhotoURL = imageViewModel.uploadAndWait(photoByteArray)
+      } catch (e: Throwable) {
+        // TODO Implement error handling
+      }
+    }
+
+
+
     return when (user) {
       is Farmer ->
           user.copy(
@@ -38,14 +54,16 @@ class EditProfileViewModel(private val officeRepository: OfficeRepository) : Vie
               address = pickedLocation,
               defaultOffice = selectedDefaultOffice,
               description = updatedDescription,
-              collected = collected)
+              collected = collected,
+              photoURL = uploadedPhotoURL)
       is Vet ->
           user.copy(
               firstname = firstname,
               lastname = lastname,
               address = pickedLocation,
               description = updatedDescription,
-              collected = collected)
+              collected = collected,
+              photoURL = uploadedPhotoURL)
     }
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -8,6 +8,7 @@ import com.android.agrihealth.data.model.user.Farmer
 import com.android.agrihealth.data.model.user.User
 import com.android.agrihealth.data.model.user.Vet
 
+// TODO Refactor this screen to have an uiState variable and move code from screen to this viewModel
 class EditProfileViewModel(
   private val officeRepository: OfficeRepository,
   private val imageViewModel: ImageViewModel

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -21,7 +21,8 @@ class EditProfileViewModel(
       selectedDefaultOffice: String?,
       description: String,
       collected: Boolean,
-      photoByteArray: ByteArray?
+      photoByteArray: ByteArray?,
+      removeRemotePhoto: Boolean,
   ): User? {
     val updatedDescription = description.ifBlank { null }
 
@@ -35,13 +36,17 @@ class EditProfileViewModel(
       }
     }
 
-    var uploadedPhotoURL: String? = null
-    if (photoByteArray != null) {
-      try {
-        uploadedPhotoURL = imageViewModel.uploadAndWait(photoByteArray)
-      } catch (e: Throwable) {
-        // TODO Implement error handling
+    val finalPhotoUrl: String? = when {
+      photoByteArray != null -> {  // user picked a new photo
+        try {
+          imageViewModel.uploadAndWait(photoByteArray)
+        } catch (e: Throwable) {
+          // TODO: handle error (and probably return null / keep previous)
+          null
+        }
       }
+      removeRemotePhoto -> null  // Users wants to remove current remote photo
+      else -> user.photoURL  // User did nothing
     }
 
 
@@ -55,7 +60,7 @@ class EditProfileViewModel(
               defaultOffice = selectedDefaultOffice,
               description = updatedDescription,
               collected = collected,
-              photoURL = uploadedPhotoURL)
+              photoURL = finalPhotoUrl )
       is Vet ->
           user.copy(
               firstname = firstname,
@@ -63,7 +68,7 @@ class EditProfileViewModel(
               address = pickedLocation,
               description = updatedDescription,
               collected = collected,
-              photoURL = uploadedPhotoURL)
+              photoURL = finalPhotoUrl )
     }
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -42,11 +42,11 @@ class EditProfileViewModel(
         try {
           imageViewModel.uploadAndWait(photoByteArray)
         } catch (e: Throwable) {
-          // TODO: handle error (and probably return null / keep previous)
+          // TODO: Handle error
           null
         }
       }
-      removeRemotePhoto -> null  // Users wants to remove current remote photo
+      removeRemotePhoto -> null  // User wants to remove current remote photo
       else -> user.photoURL  // User did nothing
     }
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -9,7 +9,6 @@ import com.android.agrihealth.data.model.user.User
 import com.android.agrihealth.data.model.user.Vet
 import com.android.agrihealth.ui.utils.PhotoUi
 
-// TODO Refactor this screen to have an uiState variable and move code from screen to this viewModel
 class EditProfileViewModel(
     private val officeRepository: OfficeRepository,
     private val imageViewModel: ImageViewModel

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -7,12 +7,26 @@ import com.android.agrihealth.data.model.office.OfficeRepository
 import com.android.agrihealth.data.model.user.Farmer
 import com.android.agrihealth.data.model.user.User
 import com.android.agrihealth.data.model.user.Vet
+import com.android.agrihealth.ui.utils.PhotoUi
 
 // TODO Refactor this screen to have an uiState variable and move code from screen to this viewModel
 class EditProfileViewModel(
     private val officeRepository: OfficeRepository,
     private val imageViewModel: ImageViewModel
 ) : ViewModel() {
+
+  /** Decides which photo to display depending on the
+   * state of the UI (i.e if a photo has been removed, picked, ...) */
+  fun choosePhotoToDisplay(
+    remotePhotoURL: String?,
+    localPhotoBytes: ByteArray?,
+    removeRemotePhoto: Boolean
+  ): PhotoUi = when {
+    localPhotoBytes != null -> PhotoUi.Local(localPhotoBytes)
+    removeRemotePhoto -> PhotoUi.Empty
+    remotePhotoURL != null -> PhotoUi.Remote(remotePhotoURL)
+    else -> PhotoUi.Empty
+  }
 
   suspend fun saveProfileChanges(
       user: User,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -10,8 +10,8 @@ import com.android.agrihealth.data.model.user.Vet
 
 // TODO Refactor this screen to have an uiState variable and move code from screen to this viewModel
 class EditProfileViewModel(
-  private val officeRepository: OfficeRepository,
-  private val imageViewModel: ImageViewModel
+    private val officeRepository: OfficeRepository,
+    private val imageViewModel: ImageViewModel
 ) : ViewModel() {
 
   suspend fun saveProfileChanges(
@@ -37,20 +37,19 @@ class EditProfileViewModel(
       }
     }
 
-    val finalPhotoUrl: String? = when {
-      photoByteArray != null -> {  // user picked a new photo
-        try {
-          imageViewModel.uploadAndWait(photoByteArray)
-        } catch (e: Throwable) {
-          // TODO: Handle error
-          null
+    val finalPhotoUrl: String? =
+        when {
+          photoByteArray != null -> { // user picked a new photo
+            try {
+              imageViewModel.uploadAndWait(photoByteArray)
+            } catch (e: Throwable) {
+              // TODO: Handle error
+              null
+            }
+          }
+          removeRemotePhoto -> null // User wants to remove current remote photo
+          else -> user.photoURL // User did nothing
         }
-      }
-      removeRemotePhoto -> null  // User wants to remove current remote photo
-      else -> user.photoURL  // User did nothing
-    }
-
-
 
     return when (user) {
       is Farmer ->
@@ -61,7 +60,7 @@ class EditProfileViewModel(
               defaultOffice = selectedDefaultOffice,
               description = updatedDescription,
               collected = collected,
-              photoURL = finalPhotoUrl )
+              photoURL = finalPhotoUrl)
       is Vet ->
           user.copy(
               firstname = firstname,
@@ -69,7 +68,7 @@ class EditProfileViewModel(
               address = pickedLocation,
               description = updatedDescription,
               collected = collected,
-              photoURL = finalPhotoUrl )
+              photoURL = finalPhotoUrl)
     }
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/EditProfileViewModel.kt
@@ -14,18 +14,21 @@ class EditProfileViewModel(
     private val imageViewModel: ImageViewModel
 ) : ViewModel() {
 
-  /** Decides which photo to display depending on the
-   * state of the UI (i.e if a photo has been removed, picked, ...) */
+  /**
+   * Decides which photo to display depending on the state of the UI (i.e if a photo has been
+   * removed, picked, ...)
+   */
   fun choosePhotoToDisplay(
-    remotePhotoURL: String?,
-    localPhotoBytes: ByteArray?,
-    removeRemotePhoto: Boolean
-  ): PhotoUi = when {
-    localPhotoBytes != null -> PhotoUi.Local(localPhotoBytes)
-    removeRemotePhoto -> PhotoUi.Empty
-    remotePhotoURL != null -> PhotoUi.Remote(remotePhotoURL)
-    else -> PhotoUi.Empty
-  }
+      remotePhotoURL: String?,
+      localPhotoBytes: ByteArray?,
+      removeRemotePhoto: Boolean
+  ): PhotoUi =
+      when {
+        localPhotoBytes != null -> PhotoUi.Local(localPhotoBytes)
+        removeRemotePhoto -> PhotoUi.Empty
+        remotePhotoURL != null -> PhotoUi.Remote(remotePhotoURL)
+        else -> PhotoUi.Empty
+      }
 
   suspend fun saveProfileChanges(
       user: User,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -187,7 +187,7 @@ fun LocalPhotoDisplay(
         photoByteArray?.let { PhotoType.ByteArray(it) }, modifier, showPlaceHolder, placeholder)
 
 /**
- *  A default profile picture icon shown when the user has no profile picture
+ * A default profile picture icon shown when the user has no profile picture
  *
  * @param modifier Modifier used to customize the layout
  */

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -127,7 +127,7 @@ private fun ActualLocalPhotoDisplay(
 ) {
   when (photo) {
     null -> {
-      placeholder(modifier)
+      if (showPlaceHolder) { placeholder(modifier) }
     }
     is ByteArray, is Uri -> {
       AsyncImage(

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -93,7 +93,7 @@ fun RemotePhotoDisplay(
     is ImageUIState.Loading -> {
       Box(modifier = modifier, contentAlignment = Alignment.Center) {
         CircularProgressIndicator(
-            modifier = Modifier.testTag(PhotoComponentsTestTags.PHOTO_LOADING_ANIMATION))
+            modifier = modifier.testTag(PhotoComponentsTestTags.PHOTO_LOADING_ANIMATION))
       }
     }
     is ImageUIState.Error -> {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -185,8 +185,9 @@ fun LocalPhotoDisplay(
 fun DefaultIconPlaceholder(modifier: Modifier = Modifier) {
   Icon(
       imageVector = Icons.Default.AccountCircle,
-      contentDescription = "Default icon",
-      modifier = modifier.testTag(PhotoComponentsTestTags.DEFAULT_ICON))
+      contentDescription = "Default Profile Picture",
+      modifier = modifier.testTag(PhotoComponentsTestTags.DEFAULT_ICON),
+      tint = MaterialTheme.colorScheme.primary)
 }
 
 /**

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -93,7 +93,7 @@ fun RemotePhotoDisplay(
     is ImageUIState.Loading -> {
       Box(modifier = modifier, contentAlignment = Alignment.Center) {
         CircularProgressIndicator(
-            modifier = modifier.testTag(PhotoComponentsTestTags.PHOTO_LOADING_ANIMATION))
+            modifier = Modifier.testTag(PhotoComponentsTestTags.PHOTO_LOADING_ANIMATION))
       }
     }
     is ImageUIState.Error -> {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -186,6 +186,11 @@ fun LocalPhotoDisplay(
     ActualLocalPhotoDisplay(
         photoByteArray?.let { PhotoType.ByteArray(it) }, modifier, showPlaceHolder, placeholder)
 
+/**
+ *  A default profile picture icon shown when the user has no profile picture
+ *
+ * @param modifier Modifier used to customize the layout
+ */
 @Composable
 fun DefaultIconPlaceholder(modifier: Modifier = Modifier) {
   Icon(

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -126,20 +126,21 @@ private fun ActualLocalPhotoDisplay(
     showPlaceHolder: Boolean = false,
     placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
 ) {
-  val model: Any? = when (photo) {
-    null -> null
-    is PhotoType.ByteArray -> photo.bytes
-    is PhotoType.Uri -> photo.uri
-  }
+  val model: Any? =
+      when (photo) {
+        null -> null
+        is PhotoType.ByteArray -> photo.bytes
+        is PhotoType.Uri -> photo.uri
+      }
 
   if (model == null) {
     if (showPlaceHolder) placeholder(modifier)
   } else {
     AsyncImage(
-      model = model,
-      contentDescription = "Uploaded image",
-      modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
-      contentScale = ContentScale.Fit)
+        model = model,
+        contentDescription = "Uploaded image",
+        modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
+        contentScale = ContentScale.Fit)
   }
 }
 
@@ -156,12 +157,13 @@ private fun ActualLocalPhotoDisplay(
  */
 @Composable
 fun LocalPhotoDisplay(
-  photoURI: Uri?,
-  modifier: Modifier = Modifier,
-  showPlaceHolder: Boolean = false,
-  placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
-) = ActualLocalPhotoDisplay(photoURI?.let { PhotoType.Uri(it) }, modifier, showPlaceHolder, placeholder)
-
+    photoURI: Uri?,
+    modifier: Modifier = Modifier,
+    showPlaceHolder: Boolean = false,
+    placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
+) =
+    ActualLocalPhotoDisplay(
+        photoURI?.let { PhotoType.Uri(it) }, modifier, showPlaceHolder, placeholder)
 
 /**
  * Displays the photo picked by the user before it is uploaded
@@ -176,11 +178,13 @@ fun LocalPhotoDisplay(
  */
 @Composable
 fun LocalPhotoDisplay(
-  photoByteArray: ByteArray?,
-  modifier: Modifier = Modifier,
-  showPlaceHolder: Boolean = false,
-  placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
-) = ActualLocalPhotoDisplay(photoByteArray?.let { PhotoType.ByteArray(it) }, modifier, showPlaceHolder, placeholder)
+    photoByteArray: ByteArray?,
+    modifier: Modifier = Modifier,
+    showPlaceHolder: Boolean = false,
+    placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
+) =
+    ActualLocalPhotoDisplay(
+        photoByteArray?.let { PhotoType.ByteArray(it) }, modifier, showPlaceHolder, placeholder)
 
 @Composable
 fun DefaultIconPlaceholder(modifier: Modifier = Modifier) {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -166,7 +166,7 @@ fun LocalPhotoDisplay(
  * Displays the photo picked by the user before it is uploaded
  * * (local image referenced by a ByteArray).
  *
- * @param photo ByteArray of the local photo that has not yet been uploaded.
+ * @param photoByteArray ByteArray of the local photo that has not yet been uploaded.
  * @param modifier Modifier used to customize the layout (e.g. profile picture vs report image).
  * @param showPlaceHolder If true and the photoURI is null, a default account icon is displayed
  *   instead.
@@ -175,11 +175,11 @@ fun LocalPhotoDisplay(
  */
 @Composable
 fun LocalPhotoDisplay(
-  photo: ByteArray?,
+  photoByteArray: ByteArray?,
   modifier: Modifier = Modifier,
   showPlaceHolder: Boolean = false,
-  placeholder: @Composable (Modifier) -> Unit
-) = ActualLocalPhotoDisplay(photo, modifier, showPlaceHolder, placeholder)
+  placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
+) = ActualLocalPhotoDisplay(photoByteArray, modifier, showPlaceHolder, placeholder)
 
 @Composable
 fun DefaultIconPlaceholder(modifier: Modifier = Modifier) {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.android.agrihealth.data.model.images.ImageUIState
 import com.android.agrihealth.data.model.images.ImageViewModel
+import com.android.agrihealth.data.model.images.PhotoType
 import com.android.agrihealth.ui.utils.ImagePickerDialog
 
 object PhotoComponentsTestTags {
@@ -120,7 +121,7 @@ fun RemotePhotoDisplay(
 
 @Composable
 private fun ActualLocalPhotoDisplay(
-    photo: Any?,
+    photo: PhotoType?,
     modifier: Modifier = Modifier,
     showPlaceHolder: Boolean = false,
     placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
@@ -129,15 +130,12 @@ private fun ActualLocalPhotoDisplay(
     null -> {
       if (showPlaceHolder) { placeholder(modifier) }
     }
-    is ByteArray, is Uri -> {
+    is PhotoType.ByteArray, is PhotoType.Uri -> {
       AsyncImage(
         model = photo,
         contentDescription = "Uploaded image",
         modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
         contentScale = ContentScale.Fit)
-    }
-    else -> {
-      throw IllegalArgumentException("'photo' must be either a Uri or a ByteArray")
     }
   }
 }
@@ -159,7 +157,7 @@ fun LocalPhotoDisplay(
   modifier: Modifier = Modifier,
   showPlaceHolder: Boolean = false,
   placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
-) = ActualLocalPhotoDisplay(photoURI, modifier, showPlaceHolder, placeholder)
+) = ActualLocalPhotoDisplay(photoURI?.let { PhotoType.Uri(it) }, modifier, showPlaceHolder, placeholder)
 
 
 /**
@@ -179,7 +177,7 @@ fun LocalPhotoDisplay(
   modifier: Modifier = Modifier,
   showPlaceHolder: Boolean = false,
   placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
-) = ActualLocalPhotoDisplay(photoByteArray, modifier, showPlaceHolder, placeholder)
+) = ActualLocalPhotoDisplay(photoByteArray?.let { PhotoType.ByteArray(it) }, modifier, showPlaceHolder, placeholder)
 
 @Composable
 fun DefaultIconPlaceholder(modifier: Modifier = Modifier) {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -126,17 +126,20 @@ private fun ActualLocalPhotoDisplay(
     showPlaceHolder: Boolean = false,
     placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
 ) {
-  when (photo) {
-    null -> {
-      if (showPlaceHolder) { placeholder(modifier) }
-    }
-    is PhotoType.ByteArray, is PhotoType.Uri -> {
-      AsyncImage(
-        model = photo,
-        contentDescription = "Uploaded image",
-        modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
-        contentScale = ContentScale.Fit)
-    }
+  val model: Any? = when (photo) {
+    null -> null
+    is PhotoType.ByteArray -> photo.bytes
+    is PhotoType.Uri -> photo.uri
+  }
+
+  if (model == null) {
+    if (showPlaceHolder) placeholder(modifier)
+  } else {
+    AsyncImage(
+      model = model,
+      contentDescription = "Uploaded image",
+      modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
+      contentScale = ContentScale.Fit)
   }
 }
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/PhotoComponents.kt
@@ -118,6 +118,30 @@ fun RemotePhotoDisplay(
   }
 }
 
+@Composable
+private fun ActualLocalPhotoDisplay(
+    photo: Any?,
+    modifier: Modifier = Modifier,
+    showPlaceHolder: Boolean = false,
+    placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
+) {
+  when (photo) {
+    null -> {
+      placeholder(modifier)
+    }
+    is ByteArray, is Uri -> {
+      AsyncImage(
+        model = photo,
+        contentDescription = "Uploaded image",
+        modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
+        contentScale = ContentScale.Fit)
+    }
+    else -> {
+      throw IllegalArgumentException("'photo' must be either a Uri or a ByteArray")
+    }
+  }
+}
+
 /**
  * Displays the photo picked by the user before it is uploaded
  * * (local image referenced by a URI).
@@ -131,21 +155,31 @@ fun RemotePhotoDisplay(
  */
 @Composable
 fun LocalPhotoDisplay(
-    photoURI: Uri?,
-    modifier: Modifier = Modifier,
-    showPlaceHolder: Boolean = false,
-    placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
-) {
-  if (photoURI != null) {
-    AsyncImage(
-        model = photoURI,
-        contentDescription = "Uploaded image",
-        modifier = modifier.testTag(PhotoComponentsTestTags.IMAGE_PREVIEW),
-        contentScale = ContentScale.Fit)
-  } else if (showPlaceHolder) {
-    placeholder(modifier)
-  }
-}
+  photoURI: Uri?,
+  modifier: Modifier = Modifier,
+  showPlaceHolder: Boolean = false,
+  placeholder: @Composable (Modifier) -> Unit = { DefaultIconPlaceholder(it) }
+) = ActualLocalPhotoDisplay(photoURI, modifier, showPlaceHolder, placeholder)
+
+
+/**
+ * Displays the photo picked by the user before it is uploaded
+ * * (local image referenced by a ByteArray).
+ *
+ * @param photo ByteArray of the local photo that has not yet been uploaded.
+ * @param modifier Modifier used to customize the layout (e.g. profile picture vs report image).
+ * @param showPlaceHolder If true and the photoURI is null, a default account icon is displayed
+ *   instead.
+ * @param placeholder Composable shown when `photoURI` is null and `showPlaceHolder` is true.
+ *   Defaults to a standard account icon.
+ */
+@Composable
+fun LocalPhotoDisplay(
+  photo: ByteArray?,
+  modifier: Modifier = Modifier,
+  showPlaceHolder: Boolean = false,
+  placeholder: @Composable (Modifier) -> Unit
+) = ActualLocalPhotoDisplay(photo, modifier, showPlaceHolder, placeholder)
 
 @Composable
 fun DefaultIconPlaceholder(modifier: Modifier = Modifier) {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -2,7 +2,6 @@ package com.android.agrihealth.ui.profile
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -17,7 +16,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -122,19 +120,23 @@ fun ProfileScreen(
               HorizontalDivider(modifier = Modifier.padding(bottom = 24.dp))
 
               // Profile Image Placeholder
-              Box(modifier = Modifier.testTag(ProfileScreenTestTags.PROFILE_PICTURE), contentAlignment = Alignment.Center) {
-                ProfilePicture(
-                  if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
-                  imageViewModel,
-                )
-                FloatingActionButton(
-                    onClick = onEditProfile,
-                    modifier = Modifier.testTag(EDIT_BUTTON).size(40.dp).align(Alignment.BottomEnd),
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer) {
-                      Icon(Icons.Default.Edit, contentDescription = "Edit profile")
-                    }
-              }
+              Box(
+                  modifier = Modifier.testTag(ProfileScreenTestTags.PROFILE_PICTURE),
+                  contentAlignment = Alignment.Center) {
+                    ProfilePicture(
+                        if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!)
+                        else PhotoUi.Empty,
+                        imageViewModel,
+                    )
+                    FloatingActionButton(
+                        onClick = onEditProfile,
+                        modifier =
+                            Modifier.testTag(EDIT_BUTTON).size(40.dp).align(Alignment.BottomEnd),
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer) {
+                          Icon(Icons.Default.Edit, contentDescription = "Edit profile")
+                        }
+                  }
 
               Spacer(modifier = Modifier.height(8.dp))
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -127,8 +127,6 @@ fun ProfileScreen(
                 ProfilePicture(
                   if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
                   imageViewModel,
-                  imageSize = 120.dp,
-                  modifier = Modifier,
                 )
                 FloatingActionButton(
                     onClick = onEditProfile,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -44,7 +44,6 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
-import com.android.agrihealth.ui.utils.EditableProfilePicture
 import com.android.agrihealth.ui.utils.PhotoUi
 import com.android.agrihealth.ui.utils.ProfilePicture
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -119,7 +119,6 @@ fun ProfileScreen(
             verticalArrangement = Arrangement.Top) {
               HorizontalDivider(modifier = Modifier.padding(bottom = 24.dp))
 
-              // Profile Image Placeholder
               Box(
                   modifier = Modifier.testTag(ProfileScreenTestTags.PROFILE_PICTURE),
                   contentAlignment = Alignment.Center) {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -48,7 +48,6 @@ import com.android.agrihealth.ui.user.UserViewModelContract
 object ProfileScreenTestTags {
 
   const val TOP_BAR = "TopBar"
-  const val PROFILE_IMAGE = "ProfileImage"
   const val NAME_TEXT = "NameText"
   const val EDIT_BUTTON = "EditButton"
   const val DESCRIPTION_FIELD = "DescriptionField"
@@ -57,6 +56,7 @@ object ProfileScreenTestTags {
   const val CODE_BUTTON_FARMER = "CodeButtonFarmer"
   const val MANAGE_OFFICE_BUTTON = "ManageOfficeButton"
   const val GENERATE_CODE_BUTTON = "GenerateCodeButton"
+  const val PROFILE_PICTURE = "ProfilePicture"
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -120,7 +120,7 @@ fun ProfileScreen(
               HorizontalDivider(modifier = Modifier.padding(bottom = 24.dp))
 
               // Profile Image Placeholder
-              Box(modifier = Modifier, contentAlignment = Alignment.Center) {
+              Box(modifier = Modifier.testTag(ProfileScreenTestTags.PROFILE_PICTURE), contentAlignment = Alignment.Center) {
                 RemotePhotoDisplay(
                     user.photoURL,
                     imageViewModel,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -44,6 +44,9 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
 import com.android.agrihealth.ui.user.UserViewModelContract
+import com.android.agrihealth.ui.utils.EditableProfilePicture
+import com.android.agrihealth.ui.utils.PhotoUi
+import com.android.agrihealth.ui.utils.ProfilePicture
 
 object ProfileScreenTestTags {
 
@@ -121,13 +124,12 @@ fun ProfileScreen(
 
               // Profile Image Placeholder
               Box(modifier = Modifier.testTag(ProfileScreenTestTags.PROFILE_PICTURE), contentAlignment = Alignment.Center) {
-                RemotePhotoDisplay(
-                    user.photoURL,
-                    imageViewModel,
-                    contentDescription = "Profile Picture",
-                    showPlaceHolder = true,
-                    modifier = Modifier.size(120.dp).clip(CircleShape),
-                ) // TODO Use profile picture component
+                ProfilePicture(
+                  if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
+                  imageViewModel,
+                  imageSize = 120.dp,
+                  modifier = Modifier,
+                )
                 FloatingActionButton(
                     onClick = onEditProfile,
                     modifier = Modifier.testTag(EDIT_BUTTON).size(40.dp).align(Alignment.BottomEnd),

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -41,7 +40,6 @@ import com.android.agrihealth.ui.profile.ProfileScreenTestTags.DESCRIPTION_FIELD
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.EDIT_BUTTON
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.MANAGE_OFFICE_BUTTON
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.NAME_TEXT
-import com.android.agrihealth.ui.profile.ProfileScreenTestTags.PROFILE_IMAGE
 import com.android.agrihealth.ui.profile.ProfileScreenTestTags.TOP_BAR
 import com.android.agrihealth.ui.report.CollectedSwitch
 import com.android.agrihealth.ui.user.UserViewModel
@@ -124,10 +122,12 @@ fun ProfileScreen(
               // Profile Image Placeholder
               Box(modifier = Modifier, contentAlignment = Alignment.Center) {
                 RemotePhotoDisplay(
-                  user.photoURL, imageViewModel,
-                  contentDescription = "Profile Picture",
-                  showPlaceHolder = true,
-                  modifier = Modifier.size(120.dp).clip(CircleShape),) // TODO Use profile picture component
+                    user.photoURL,
+                    imageViewModel,
+                    contentDescription = "Profile Picture",
+                    showPlaceHolder = true,
+                    modifier = Modifier.size(120.dp).clip(CircleShape),
+                ) // TODO Use profile picture component
                 FloatingActionButton(
                     onClick = onEditProfile,
                     modifier = Modifier.testTag(EDIT_BUTTON).size(40.dp).align(Alignment.BottomEnd),

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.agrihealth.data.model.connection.ConnectionRepositoryProvider
+import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.data.model.user.*
 import com.android.agrihealth.ui.authentification.SignInScreenTestTags.EMAIL_FIELD
 import com.android.agrihealth.ui.authentification.SignInScreenTestTags.PASSWORD_FIELD
@@ -64,6 +65,7 @@ object ProfileScreenTestTags {
 @Composable
 fun ProfileScreen(
     userViewModel: UserViewModelContract = viewModel<UserViewModel>(),
+    imageViewModel: ImageViewModel = viewModel(),
     onGoBack: () -> Unit = {},
     onLogout: () -> Unit = {},
     onEditProfile: () -> Unit = {},
@@ -121,12 +123,11 @@ fun ProfileScreen(
 
               // Profile Image Placeholder
               Box(modifier = Modifier, contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector =
-                        Icons.Default.AccountCircle, // To change to actual image when available
-                    contentDescription = "Profile Picture",
-                    modifier = Modifier.size(120.dp).clip(CircleShape).testTag(PROFILE_IMAGE),
-                    tint = MaterialTheme.colorScheme.primary)
+                RemotePhotoDisplay(
+                  user.photoURL, imageViewModel,
+                  contentDescription = "Profile Picture",
+                  showPlaceHolder = true,
+                  modifier = Modifier.size(120.dp).clip(CircleShape),) // TODO Use profile picture component
                 FloatingActionButton(
                     onClick = onEditProfile,
                     modifier = Modifier.testTag(EDIT_BUTTON).size(40.dp).align(Alignment.BottomEnd),

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -4,7 +4,6 @@ import android.widget.Toast
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -13,14 +12,12 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.data.model.user.*
-import com.android.agrihealth.ui.profile.RemotePhotoDisplay
 import com.android.agrihealth.ui.utils.PhotoUi
 import com.android.agrihealth.ui.utils.ProfilePicture
 
@@ -113,10 +110,9 @@ private fun ViewUserContent(user: User, officeName: String?, imageViewModel: Ima
               .padding(16.dp)
               .testTag(ViewUserScreenTestTags.CONTENT_COLUMN),
       horizontalAlignment = Alignment.CenterHorizontally) {
-
         ProfilePicture(
-          photo = if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
-          imageViewModel,
+            photo = if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
+            imageViewModel,
         )
 
         Spacer(Modifier.height(24.dp))

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -110,10 +110,14 @@ private fun ViewUserContent(user: User, officeName: String?, imageViewModel: Ima
               .padding(16.dp)
               .testTag(ViewUserScreenTestTags.CONTENT_COLUMN),
       horizontalAlignment = Alignment.CenterHorizontally) {
-        ProfilePicture(
-            photo = if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
-            imageViewModel,
-        )
+
+        // Box needed for testing purpose
+        Box(modifier = Modifier.testTag(ViewUserScreenTestTags.PROFILE_PICTURE)) {
+          ProfilePicture(
+              photo = if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
+              imageViewModel,
+          )
+        }
 
         Spacer(Modifier.height(24.dp))
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.*
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
@@ -112,12 +111,13 @@ private fun ViewUserContent(user: User, officeName: String?, imageViewModel: Ima
               .padding(16.dp)
               .testTag(ViewUserScreenTestTags.CONTENT_COLUMN),
       horizontalAlignment = Alignment.CenterHorizontally) {
-
         RemotePhotoDisplay(
-          user.photoURL, imageViewModel,
-          contentDescription = "Profile Picture",
-          showPlaceHolder = true,
-          modifier = Modifier.size(120.dp).clip(CircleShape),) // TODO Use profile picture component
+            user.photoURL,
+            imageViewModel,
+            contentDescription = "Profile Picture",
+            showPlaceHolder = true,
+            modifier = Modifier.size(120.dp).clip(CircleShape),
+        ) // TODO Use profile picture component
 
         Spacer(Modifier.height(24.dp))
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.data.model.user.*
 import com.android.agrihealth.ui.profile.RemotePhotoDisplay
+import com.android.agrihealth.ui.utils.PhotoUi
+import com.android.agrihealth.ui.utils.ProfilePicture
 
 object ViewUserScreenTestTags {
   const val TOP_BAR = "ViewUserTopBar"
@@ -111,13 +113,11 @@ private fun ViewUserContent(user: User, officeName: String?, imageViewModel: Ima
               .padding(16.dp)
               .testTag(ViewUserScreenTestTags.CONTENT_COLUMN),
       horizontalAlignment = Alignment.CenterHorizontally) {
-        RemotePhotoDisplay(
-            user.photoURL,
-            imageViewModel,
-            contentDescription = "Profile Picture",
-            showPlaceHolder = true,
-            modifier = Modifier.size(120.dp).clip(CircleShape).testTag(ViewUserScreenTestTags.PROFILE_PICTURE),
-        ) // TODO Use profile picture component
+
+        ProfilePicture(
+          photo = if (user.photoURL != null) PhotoUi.Remote(user.photoURL!!) else PhotoUi.Empty,
+          imageViewModel,
+        )
 
         Spacer(Modifier.height(24.dp))
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -13,11 +14,14 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.data.model.user.*
+import com.android.agrihealth.ui.profile.RemotePhotoDisplay
 
 object ViewUserScreenTestTags {
   const val TOP_BAR = "ViewUserTopBar"
@@ -38,7 +42,8 @@ object ViewUserScreenTestTags {
 fun ViewUserScreen(
     viewModel: ViewUserViewModel,
     onBack: () -> Unit,
-    userViewModel: UserViewModel = viewModel()
+    userViewModel: UserViewModel = viewModel(),
+    imageViewModel: ImageViewModel = viewModel(),
 ) {
   val uiState by viewModel.uiState
 
@@ -88,7 +93,7 @@ fun ViewUserScreen(
                 }
             is ViewUserUiState.Success -> {
               val success = uiState as ViewUserUiState.Success
-              ViewUserContent(user = success.user, officeName = success.officeName)
+              ViewUserContent(user = success.user, officeName = success.officeName, imageViewModel)
             }
           }
         }
@@ -96,7 +101,7 @@ fun ViewUserScreen(
 }
 
 @Composable
-private fun ViewUserContent(user: User, officeName: String?) {
+private fun ViewUserContent(user: User, officeName: String?, imageViewModel: ImageViewModel) {
   val scroll = rememberScrollState()
   val noInteraction = remember { MutableInteractionSource() }
 
@@ -107,10 +112,12 @@ private fun ViewUserContent(user: User, officeName: String?) {
               .padding(16.dp)
               .testTag(ViewUserScreenTestTags.CONTENT_COLUMN),
       horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(
-            imageVector = Icons.Default.AccountCircle,
-            contentDescription = "Profile",
-            modifier = Modifier.size(120.dp).testTag(ViewUserScreenTestTags.PROFILE_ICON))
+
+        RemotePhotoDisplay(
+          user.photoURL, imageViewModel,
+          contentDescription = "Profile Picture",
+          showPlaceHolder = true,
+          modifier = Modifier.size(120.dp).clip(CircleShape),) // TODO Use profile picture component
 
         Spacer(Modifier.height(24.dp))
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -28,7 +28,7 @@ object ViewUserScreenTestTags {
   const val LOADING_INDICATOR = "ViewUserLoadingIndicator"
   const val ERROR_TEXT = "ViewUserErrorText"
   const val CONTENT_COLUMN = "ViewUserContentColumn"
-  const val PROFILE_ICON = "ViewUserProfileIcon"
+  const val PROFILE_PICTURE = "ViewUserProfilePicture"
   const val NAME_FIELD = "ViewUserNameField"
   const val ROLE_FIELD = "ViewUserRoleField"
   const val OFFICE_FIELD = "ViewUserOfficeField"
@@ -116,7 +116,7 @@ private fun ViewUserContent(user: User, officeName: String?, imageViewModel: Ima
             imageViewModel,
             contentDescription = "Profile Picture",
             showPlaceHolder = true,
-            modifier = Modifier.size(120.dp).clip(CircleShape),
+            modifier = Modifier.size(120.dp).clip(CircleShape).testTag(ViewUserScreenTestTags.PROFILE_PICTURE),
         ) // TODO Use profile picture component
 
         Spacer(Modifier.height(24.dp))

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/Converter.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/Converter.kt
@@ -1,0 +1,30 @@
+package com.android.agrihealth.ui.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import java.io.ByteArrayOutputStream
+
+// TODO Add documentation
+
+// Created with the help of an LLM
+fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG, quality: Int = 100): ByteArray {
+  val bitmap = this.asAndroidBitmap()
+  val outputStream = ByteArrayOutputStream()
+  bitmap.compress(format, quality, outputStream)
+  return outputStream.toByteArray()
+}
+
+// Created with the help of an LLM
+fun Uri.toBitmap(context: Context): Bitmap {
+  val source = ImageDecoder.createSource(context.contentResolver, this)
+
+  // Forcing to use software allocator (instead of hardware) and forcing bitmap to be mutable to prevent issues when cropping the photo
+  return ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
+    decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+    decoder.isMutableRequired = true
+  }
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/Converter.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/Converter.kt
@@ -8,15 +8,17 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import java.io.ByteArrayOutputStream
 
-
 // Created with the help of an LLM
 /**
- *  Converts this [ImageBitmap] into a [ByteArray]
+ * Converts this [ImageBitmap] into a [ByteArray]
  *
- *  @param format The output format, default to a PNG
- *  @param quality The quality of the output, defaults to 100% (i.e no compression)
+ * @param format The output format, default to a PNG
+ * @param quality The quality of the output, defaults to 100% (i.e no compression)
  */
-fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG, quality: Int = 100): ByteArray {
+fun ImageBitmap.toByteArray(
+    format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG,
+    quality: Int = 100
+): ByteArray {
   val bitmap = this.asAndroidBitmap()
   val outputStream = ByteArrayOutputStream()
   bitmap.compress(format, quality, outputStream)
@@ -25,14 +27,15 @@ fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressForma
 
 // Created with the help of an LLM
 /**
- *  Returns a [BitMap] representing the file that this [Uri] points to
+ * Returns a [BitMap] representing the file that this [Uri] points to
  *
- *  @param context The environment [Context]
+ * @param context The environment [Context]
  */
 fun Uri.toBitmap(context: Context): Bitmap {
   val source = ImageDecoder.createSource(context.contentResolver, this)
 
-  // Forcing to use software allocator (instead of hardware) and forcing bitmap to be mutable to prevent issues when cropping the photo
+  // Forcing to use software allocator (instead of hardware) and forcing bitmap to be mutable to
+  // prevent issues when cropping the photo
   return ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
     decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
     decoder.isMutableRequired = true

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/Converter.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/Converter.kt
@@ -8,9 +8,14 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import java.io.ByteArrayOutputStream
 
-// TODO Add documentation
 
 // Created with the help of an LLM
+/**
+ *  Converts this [ImageBitmap] into a [ByteArray]
+ *
+ *  @param format The output format, default to a PNG
+ *  @param quality The quality of the output, defaults to 100% (i.e no compression)
+ */
 fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG, quality: Int = 100): ByteArray {
   val bitmap = this.asAndroidBitmap()
   val outputStream = ByteArrayOutputStream()
@@ -19,6 +24,11 @@ fun ImageBitmap.toByteArray(format: Bitmap.CompressFormat = Bitmap.CompressForma
 }
 
 // Created with the help of an LLM
+/**
+ *  Returns a [BitMap] representing the file that this [Uri] points to
+ *
+ *  @param context The environment [Context]
+ */
 fun Uri.toBitmap(context: Context): Bitmap {
   val source = ImageDecoder.createSource(context.contentResolver, this)
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ImagePicker.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ImagePicker.kt
@@ -41,9 +41,10 @@ object ImagePickerTexts {
   const val PERMISSION_REQUIRED = "Camera permission is required to take a photo"
 }
 
- // Generative AI was used in the making of this file in order to move the original code in
- // AddReportScreen.kt into its own standalone file
- /**
+/**
+ * Generative AI was used in the making of this file in order to move the original code in
+ * AddReportScreen.kt into its own standalone file
+ *
  * A complete, self-contained image picker component that handles:
  * - Showing a dialog to choose between gallery and camera
  * - Requesting camera permissions

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ImagePicker.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ImagePicker.kt
@@ -41,10 +41,9 @@ object ImagePickerTexts {
   const val PERMISSION_REQUIRED = "Camera permission is required to take a photo"
 }
 
-/**
- * Generative AI was used in the making of this file in order to move the original code in
- * AddReportScreen.kt into its own standalone file
- *
+ // Generative AI was used in the making of this file in order to move the original code in
+ // AddReportScreen.kt into its own standalone file
+ /**
  * A complete, self-contained image picker component that handles:
  * - Showing a dialog to choose between gallery and camera
  * - Requesting camera permissions

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -22,8 +22,14 @@ import com.mr0xf00.easycrop.ImageCropper
 import com.mr0xf00.easycrop.ui.ImageCropperDialog
 
 
-// TODO: Add documentation
 // TODO Allow crop region to be square (to allow later to have square profile picture shape for office
+/**
+ *  Display the photo cropper dialog which allows the user to crop the selected photo
+ *  An [ImageCropper] must be supplied beforehand, which should be created and remembered in the composition
+ *  with ```rememberImageCropper()```
+ *
+ *  @param imageCropper The supplied [imageCropper]
+ */
 @Composable
 fun ShowImageCropperDialog(imageCropper: ImageCropper) {
   val cropState = imageCropper.cropState!!
@@ -46,7 +52,7 @@ fun ShowImageCropperDialog(imageCropper: ImageCropper) {
     ))
 }
 
-// Replacing the default topbar of the image cropper (specifically change the reset button)
+// Replacing the default topbar of the image cropper (specifically changes the reset button)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ImageCropperCustomTopBar(state: CropState) {
@@ -73,6 +79,7 @@ private fun ImageCropperCustomTopBar(state: CropState) {
 // Force the shape of the image cropper to be a circle
 private fun setImageCropperShapeCircle(state: CropState) {
   state.reset()
+
   // Force the region to be square
   val currentRegion = state.region
   val size = minOf(currentRegion.width, currentRegion.height)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -21,8 +21,7 @@ import com.mr0xf00.easycrop.CropperStyle
 import com.mr0xf00.easycrop.ImageCropper
 import com.mr0xf00.easycrop.ui.ImageCropperDialog
 
-// TODO Allow crop region to be square (to allow later to have square profile picture shape for
-// office
+
 /**
  * Display the photo cropper dialog which allows the user to crop the selected photo An
  * [ImageCropper] must be supplied beforehand, which should be created and remembered in the
@@ -79,15 +78,7 @@ private fun setImageCropperShapeCircle(state: CropState) {
   // Force the region to be square
   val currentRegion = state.region
   val size = minOf(currentRegion.width, currentRegion.height)
-  val centerX = currentRegion.center.x
-  val centerY = currentRegion.center.y
-
-  state.region =
-      Rect(
-          left = centerX - size / 2f,
-          top = centerY - size / 2f,
-          right = centerX + size / 2f,
-          bottom = centerY + size / 2f)
+  state.region = Rect(currentRegion.center, size /2f)
 
   state.aspectLock = true
   state.shape = CircleCropShape

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -31,7 +31,6 @@ import com.mr0xf00.easycrop.ui.ImageCropperDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-
 /** To make type more clear */
 typealias ImageCropperLauncher = (Uri) -> Unit
 
@@ -48,12 +47,12 @@ typealias ImageCropperLauncher = (Uri) -> Unit
  */
 @Composable
 fun rememberDefaultImageCropperLauncher(
-  imageCropper: ImageCropper,
-  cropMaxSize: IntSize = IntSize(8192, 8192),
-  scope: CoroutineScope,
-  onCropSuccess: (ByteArray) -> Unit,
-  onCropError: (String) -> Unit,
-  onCropCancelled: () -> Unit = {},
+    imageCropper: ImageCropper,
+    cropMaxSize: IntSize = IntSize(8192, 8192),
+    scope: CoroutineScope,
+    onCropSuccess: (ByteArray) -> Unit,
+    onCropError: (String) -> Unit,
+    onCropCancelled: () -> Unit = {},
 ): ImageCropperLauncher {
   val context = LocalContext.current
 
@@ -65,11 +64,11 @@ fun rememberDefaultImageCropperLauncher(
         when (val result = imageCropper.crop(cropMaxSize, bmp = bitmap)) {
           is CropResult.Cancelled -> onCropCancelled()
           is CropError ->
-            onCropError(
-              when (result) {
-                CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
-                CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
-              })
+              onCropError(
+                  when (result) {
+                    CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
+                    CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
+                  })
           is CropResult.Success -> onCropSuccess(result.bitmap.toByteArray())
         }
       }
@@ -133,7 +132,7 @@ private fun setImageCropperShapeCircle(state: CropState) {
   // Force the region to be square
   val currentRegion = state.region
   val size = minOf(currentRegion.width, currentRegion.height)
-  state.region = Rect(currentRegion.center, size /2f)
+  state.region = Rect(currentRegion.center, size / 2f)
 
   state.aspectLock = true
   state.shape = CircleCropShape

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -1,6 +1,7 @@
 package com.android.agrihealth.ui.utils
 
 import android.net.Uri
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
@@ -14,10 +15,12 @@ import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntSize
 import com.mr0xf00.easycrop.AspectRatio
 import com.mr0xf00.easycrop.CircleCropShape
@@ -30,6 +33,10 @@ import com.mr0xf00.easycrop.crop
 import com.mr0xf00.easycrop.ui.ImageCropperDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+
+object PhotoCropperTestTags {
+  const val CROPPER_WINDOW = "CropperWindow"
+}
 
 /** To make type more clear */
 typealias ImageCropperLauncher = (Uri) -> Unit
@@ -90,17 +97,19 @@ fun ShowImageCropperDialog(imageCropper: ImageCropper) {
   // Setting this once
   LaunchedEffect(cropState) { setImageCropperShapeCircle(cropState) }
 
-  ImageCropperDialog(
-      state = cropState,
-      topBar = { ImageCropperCustomTopBar(cropState) },
-      cropControls = {},
-      style =
-          CropperStyle(
-              autoZoom = true,
-              guidelines = null,
-              shapes = listOf(CircleCropShape),
-              overlay = Color.Black.copy(alpha = .6f),
-              aspects = listOf(AspectRatio(1, 1))))
+  Box(modifier = Modifier.testTag(PhotoCropperTestTags.CROPPER_WINDOW)) {
+    ImageCropperDialog(
+        state = cropState,
+        topBar = { ImageCropperCustomTopBar(cropState) },
+        cropControls = {},
+        style =
+            CropperStyle(
+                autoZoom = true,
+                guidelines = null,
+                shapes = listOf(CircleCropShape),
+                overlay = Color.Black.copy(alpha = .6f),
+                aspects = listOf(AspectRatio(1, 1))))
+  }
 }
 
 // Replacing the default topbar of the image cropper (specifically changes the reset button)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -1,5 +1,6 @@
 package com.android.agrihealth.ui.utils
 
+import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
@@ -12,15 +13,69 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.IntSize
 import com.mr0xf00.easycrop.AspectRatio
 import com.mr0xf00.easycrop.CircleCropShape
+import com.mr0xf00.easycrop.CropError
+import com.mr0xf00.easycrop.CropResult
 import com.mr0xf00.easycrop.CropState
 import com.mr0xf00.easycrop.CropperStyle
 import com.mr0xf00.easycrop.ImageCropper
+import com.mr0xf00.easycrop.crop
 import com.mr0xf00.easycrop.ui.ImageCropperDialog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
+
+/** To make type more clear */
+typealias ImageCropperLauncher = (Uri) -> Unit
+
+/**
+ * Initializes and remembers an image cropper created by default
+ *
+ * @param imageCropper The supplied [ImageCropper]
+ * @param cropMaxSize The maximum size of the crop region. Prefer leaving it as is
+ * @param scope The scope at which new coroutines will be created
+ * @param onCropSuccess Called when the user succesfully chose and cropped a photo
+ * @param onCropError Called when the user chose a picture and tried to crop if but it failed
+ * @param onCropCancelled Called when the user cancels the crop (by dismissing the window for
+ *   example)
+ */
+@Composable
+fun rememberDefaultImageCropperLauncher(
+  imageCropper: ImageCropper,
+  cropMaxSize: IntSize = IntSize(8192, 8192),
+  scope: CoroutineScope,
+  onCropSuccess: (ByteArray) -> Unit,
+  onCropError: (String) -> Unit,
+  onCropCancelled: () -> Unit = {},
+): ImageCropperLauncher {
+  val context = LocalContext.current
+
+  // Not sure what keys to put there (if any at all?)
+  return remember(imageCropper, onCropSuccess, onCropError, onCropCancelled) {
+    { uri: Uri ->
+      scope.launch {
+        val bitmap = uri.toBitmap(context).asImageBitmap()
+        when (val result = imageCropper.crop(cropMaxSize, bmp = bitmap)) {
+          is CropResult.Cancelled -> onCropCancelled()
+          is CropError ->
+            onCropError(
+              when (result) {
+                CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
+                CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
+              })
+          is CropResult.Success -> onCropSuccess(result.bitmap.toByteArray())
+        }
+      }
+    }
+  }
+}
 
 /**
  * Display the photo cropper dialog which allows the user to crop the selected photo An

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -21,59 +21,55 @@ import com.mr0xf00.easycrop.CropperStyle
 import com.mr0xf00.easycrop.ImageCropper
 import com.mr0xf00.easycrop.ui.ImageCropperDialog
 
-
-// TODO Allow crop region to be square (to allow later to have square profile picture shape for office
+// TODO Allow crop region to be square (to allow later to have square profile picture shape for
+// office
 /**
- *  Display the photo cropper dialog which allows the user to crop the selected photo
- *  An [ImageCropper] must be supplied beforehand, which should be created and remembered in the composition
- *  with ```rememberImageCropper()```
+ * Display the photo cropper dialog which allows the user to crop the selected photo An
+ * [ImageCropper] must be supplied beforehand, which should be created and remembered in the
+ * composition with ```rememberImageCropper()```
  *
- *  @param imageCropper The supplied [imageCropper]
+ * @param imageCropper The supplied [imageCropper]
  */
 @Composable
 fun ShowImageCropperDialog(imageCropper: ImageCropper) {
   val cropState = imageCropper.cropState!!
 
   // Setting this once
-  LaunchedEffect(cropState) {
-    setImageCropperShapeCircle(cropState)
-  }
+  LaunchedEffect(cropState) { setImageCropperShapeCircle(cropState) }
 
   ImageCropperDialog(
-    state = cropState,
-    topBar = { ImageCropperCustomTopBar(cropState) },
-    cropControls = {},
-    style = CropperStyle(
-      autoZoom = true,
-      guidelines = null,
-      shapes = listOf(CircleCropShape),
-      overlay = Color.Black.copy(alpha = .6f),
-      aspects = listOf(AspectRatio(1, 1))
-    ))
+      state = cropState,
+      topBar = { ImageCropperCustomTopBar(cropState) },
+      cropControls = {},
+      style =
+          CropperStyle(
+              autoZoom = true,
+              guidelines = null,
+              shapes = listOf(CircleCropShape),
+              overlay = Color.Black.copy(alpha = .6f),
+              aspects = listOf(AspectRatio(1, 1))))
 }
 
 // Replacing the default topbar of the image cropper (specifically changes the reset button)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ImageCropperCustomTopBar(state: CropState) {
-  TopAppBar(title = {},
-    navigationIcon = {
-      IconButton(onClick = { state.done(accept = false) }) {
-        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Cancel cropping")
-      }
-    },
-    actions = {
-      IconButton(onClick = {
-        setImageCropperShapeCircle(state)
-      }) {
-        Icon(Icons.Default.Replay, contentDescription = "Restore")
-      }
-      IconButton(onClick = { state.done(accept = true) }, enabled = !state.accepted) {
-        Icon(Icons.Default.Done, contentDescription = "Submit")
-      }
-    },
-    colors = topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
-  )
+  TopAppBar(
+      title = {},
+      navigationIcon = {
+        IconButton(onClick = { state.done(accept = false) }) {
+          Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Cancel cropping")
+        }
+      },
+      actions = {
+        IconButton(onClick = { setImageCropperShapeCircle(state) }) {
+          Icon(Icons.Default.Replay, contentDescription = "Restore")
+        }
+        IconButton(onClick = { state.done(accept = true) }, enabled = !state.accepted) {
+          Icon(Icons.Default.Done, contentDescription = "Submit")
+        }
+      },
+      colors = topAppBarColors(containerColor = MaterialTheme.colorScheme.surface))
 }
 
 // Force the shape of the image cropper to be a circle
@@ -86,12 +82,12 @@ private fun setImageCropperShapeCircle(state: CropState) {
   val centerX = currentRegion.center.x
   val centerY = currentRegion.center.y
 
-  state.region = Rect(
-    left = centerX - size / 2f,
-    top = centerY - size / 2f,
-    right = centerX + size / 2f,
-    bottom = centerY + size / 2f
-  )
+  state.region =
+      Rect(
+          left = centerX - size / 2f,
+          top = centerY - size / 2f,
+          right = centerX + size / 2f,
+          bottom = centerY + size / 2f)
 
   state.aspectLock = true
   state.shape = CircleCropShape

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/PhotoCropper.kt
@@ -1,0 +1,91 @@
+package com.android.agrihealth.ui.utils
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import com.mr0xf00.easycrop.AspectRatio
+import com.mr0xf00.easycrop.CircleCropShape
+import com.mr0xf00.easycrop.CropState
+import com.mr0xf00.easycrop.CropperStyle
+import com.mr0xf00.easycrop.ImageCropper
+import com.mr0xf00.easycrop.ui.ImageCropperDialog
+
+
+// TODO: Add documentation
+// TODO Allow crop region to be square (to allow later to have square profile picture shape for office
+@Composable
+fun ShowImageCropperDialog(imageCropper: ImageCropper) {
+  val cropState = imageCropper.cropState!!
+
+  // Setting this once
+  LaunchedEffect(cropState) {
+    setImageCropperShapeCircle(cropState)
+  }
+
+  ImageCropperDialog(
+    state = cropState,
+    topBar = { ImageCropperCustomTopBar(cropState) },
+    cropControls = {},
+    style = CropperStyle(
+      autoZoom = true,
+      guidelines = null,
+      shapes = listOf(CircleCropShape),
+      overlay = Color.Black.copy(alpha = .6f),
+      aspects = listOf(AspectRatio(1, 1))
+    ))
+}
+
+// Replacing the default topbar of the image cropper (specifically change the reset button)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImageCropperCustomTopBar(state: CropState) {
+  TopAppBar(title = {},
+    navigationIcon = {
+      IconButton(onClick = { state.done(accept = false) }) {
+        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Cancel cropping")
+      }
+    },
+    actions = {
+      IconButton(onClick = {
+        setImageCropperShapeCircle(state)
+      }) {
+        Icon(Icons.Default.Replay, contentDescription = "Restore")
+      }
+      IconButton(onClick = { state.done(accept = true) }, enabled = !state.accepted) {
+        Icon(Icons.Default.Done, contentDescription = "Submit")
+      }
+    },
+    colors = topAppBarColors(containerColor = MaterialTheme.colorScheme.surface)
+  )
+}
+
+// Force the shape of the image cropper to be a circle
+private fun setImageCropperShapeCircle(state: CropState) {
+  state.reset()
+  // Force the region to be square
+  val currentRegion = state.region
+  val size = minOf(currentRegion.width, currentRegion.height)
+  val centerX = currentRegion.center.x
+  val centerY = currentRegion.center.y
+
+  state.region = Rect(
+    left = centerX - size / 2f,
+    top = centerY - size / 2f,
+    right = centerX + size / 2f,
+    bottom = centerY + size / 2f
+  )
+
+  state.aspectLock = true
+  state.shape = CircleCropShape
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -1,0 +1,85 @@
+package com.android.agrihealth.ui.utils
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.android.agrihealth.data.model.images.ImageViewModel
+import com.android.agrihealth.ui.profile.LocalPhotoDisplay
+import com.android.agrihealth.ui.profile.RemotePhotoDisplay
+
+// TODO Write kdoc
+sealed interface PhotoUi {
+  data object Empty : PhotoUi
+  data class Remote(val url: String) : PhotoUi
+  data class Local(val bytes: ByteArray) : PhotoUi
+}
+
+@Composable
+fun EditableProfilePicture(
+  photo: PhotoUi,
+  isEditable: Boolean,
+  imageViewModel: ImageViewModel,
+  modifier: Modifier = Modifier,
+  imageSize: Dp = 120.dp,
+  profilePictureTestTag: String,
+  editButtonTestTag: String,
+  onAddClicked: () -> Unit,
+  onRemoveClicked: () -> Unit,
+) {
+  Box(
+    modifier = modifier.size(imageSize),
+    contentAlignment = Alignment.Center,
+  ) {
+    when (photo) {
+      is PhotoUi.Remote -> RemotePhotoDisplay(
+        photoURL = photo.url,
+        imageViewModel = imageViewModel,
+        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(profilePictureTestTag),
+        contentDescription = "Photo",
+        showPlaceHolder = true
+      )
+      is PhotoUi.Local -> LocalPhotoDisplay(
+        photoByteArray = photo.bytes,
+        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(profilePictureTestTag),
+        showPlaceHolder = true
+      )
+      PhotoUi.Empty -> LocalPhotoDisplay(
+        photoByteArray = null,
+        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(profilePictureTestTag),
+        showPlaceHolder = true
+      )
+    }
+
+    if (isEditable) {
+      val removeMode = photo != PhotoUi.Empty
+      FloatingActionButton(
+        onClick = { if (removeMode) onRemoveClicked() else onAddClicked() },
+        modifier = Modifier
+          .size(40.dp)
+          .align(Alignment.BottomEnd)
+          .testTag(editButtonTestTag),
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+      ) {
+        Icon(
+          imageVector = if (removeMode) Icons.Default.Clear else Icons.Default.CameraAlt,
+          contentDescription = if (removeMode) "Remove photo" else "Add photo",
+          modifier = Modifier.size(20.dp)
+        )
+      }
+    }
+  }
+}

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.android.agrihealth.data.model.images.ImageViewModel
+import com.android.agrihealth.ui.profile.DefaultIconPlaceholder
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.RemotePhotoDisplay
 import com.android.agrihealth.ui.report.AddReportDialogTexts
@@ -199,6 +200,44 @@ fun EditableProfilePictureWithUI(
 }
 
 /**
+ *  A profile picture. It will fetch the photo on the repository, or show the local
+ *  photo, or show a default profile picture icon if no photo is given
+ *
+ *  @param photo A [PhotoUi] that stores the photo and its source (on the repository or local)
+ *  @param imageViewModel The [ImageViewModel] used to display the photo
+ *  @param modifier The [Modifier] used to customize the profile picture
+ *  @param imageSize The size of the image in [Dp]
+ */
+@Composable
+fun ProfilePicture(
+  photo: PhotoUi,
+  imageViewModel: ImageViewModel,
+  modifier: Modifier = Modifier,
+  imageSize: Dp = 120.dp,
+) {
+  when (photo) {
+    is PhotoUi.Remote ->
+      RemotePhotoDisplay(
+        photoURL = photo.url,
+        imageViewModel = imageViewModel,
+        modifier =
+          modifier.size(imageSize)
+            .clip(CircleShape),
+        contentDescription = "Photo",
+        showPlaceHolder = true)
+    is PhotoUi.Local ->
+      LocalPhotoDisplay(
+        photoByteArray = photo.bytes,
+        modifier =
+          Modifier.size(imageSize)
+            .clip(CircleShape),
+        showPlaceHolder = true)
+    PhotoUi.Empty ->
+      DefaultIconPlaceholder(Modifier.size(imageSize).clip(CircleShape))
+  }
+}
+
+/**
  * A profile picture is displayed, with a small icon that allows the user to either remove their
  * existing profile picture or add a enw one. What happens when the user clicks on the button must
  * be defined with [onPhotoPicked] and [onPhotoRemoved] respectfully. Prefer using
@@ -229,31 +268,13 @@ fun EditableProfilePicture(
       modifier = modifier.size(imageSize).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
       contentAlignment = Alignment.Center,
   ) {
-    when (photo) {
-      is PhotoUi.Remote ->
-          RemotePhotoDisplay(
-              photoURL = photo.url,
-              imageViewModel = imageViewModel,
-              modifier =
-                  Modifier.size(imageSize)
-                      .clip(CircleShape),
-              contentDescription = "Photo",
-              showPlaceHolder = true)
-      is PhotoUi.Local ->
-          LocalPhotoDisplay(
-              photoByteArray = photo.bytes,
-              modifier =
-                  Modifier.size(imageSize)
-                      .clip(CircleShape),
-              showPlaceHolder = true)
-      PhotoUi.Empty ->
-          LocalPhotoDisplay(
-              photoByteArray = null,
-              modifier =
-                  Modifier.size(imageSize)
-                      .clip(CircleShape),
-              showPlaceHolder = true)
-    }
+
+    ProfilePicture(
+      photo,
+      imageViewModel,
+      modifier.size(imageSize).clip(CircleShape),
+      imageSize
+    )
 
     if (isEditable) {
       val removeMode = photo != PhotoUi.Empty

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -78,6 +78,8 @@ object ProfilePictureComponentsTexts {
  * @param onPhotoPicked Called when the user picked (and cropped) a photo. This lambda contains the
  *   chosen photo as an argument
  * @param onPhotoRemoved Called when the user decides to remove the current profile picture
+ * @param imageCropperLauncher For testing purpose, an [ImageCropperLauncher] used to crop the
+ *   photo. Prefer to leave this empty
  */
 @Composable
 fun EditableProfilePictureWithImageCropper(
@@ -88,6 +90,7 @@ fun EditableProfilePictureWithImageCropper(
     imageSize: Dp = 120.dp,
     onPhotoPicked: (ByteArray) -> Unit,
     onPhotoRemoved: () -> Unit,
+    imageCropperLauncher: ImageCropperLauncher? = null,
 ) {
   val scope = rememberCoroutineScope()
 
@@ -96,7 +99,7 @@ fun EditableProfilePictureWithImageCropper(
   var errorDialogMessage by rememberSaveable { mutableStateOf("") }
 
   val imageCropper = rememberImageCropper()
-  val imageCropperLauncher: ImageCropperLauncher =
+  val defaultLauncher: ImageCropperLauncher =
       rememberDefaultImageCropperLauncher(
           imageCropper = imageCropper,
           scope = scope,
@@ -106,6 +109,7 @@ fun EditableProfilePictureWithImageCropper(
             errorDialogMessage = errorMessage
           },
       )
+  val actualLauncher = imageCropperLauncher ?: defaultLauncher
 
   val croppingIsOngoing = imageCropper.cropState != null
 
@@ -134,7 +138,7 @@ fun EditableProfilePictureWithImageCropper(
         onDismiss = { showImagePicker = false },
         onImageSelected = { uri ->
           showImagePicker = false
-          imageCropperLauncher(uri)
+          actualLauncher(uri)
         })
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -226,7 +226,7 @@ fun EditableProfilePicture(
     onPhotoRemoved: () -> Unit,
 ) {
   Box(
-      modifier = modifier.size(imageSize),
+      modifier = modifier.size(imageSize).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
       contentAlignment = Alignment.Center,
   ) {
     when (photo) {
@@ -236,8 +236,7 @@ fun EditableProfilePicture(
               imageViewModel = imageViewModel,
               modifier =
                   Modifier.size(imageSize)
-                      .clip(CircleShape)
-                      .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
+                      .clip(CircleShape),
               contentDescription = "Photo",
               showPlaceHolder = true)
       is PhotoUi.Local ->
@@ -245,16 +244,14 @@ fun EditableProfilePicture(
               photoByteArray = photo.bytes,
               modifier =
                   Modifier.size(imageSize)
-                      .clip(CircleShape)
-                      .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
+                      .clip(CircleShape),
               showPlaceHolder = true)
       PhotoUi.Empty ->
           LocalPhotoDisplay(
               photoByteArray = null,
               modifier =
                   Modifier.size(imageSize)
-                      .clip(CircleShape)
-                      .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
+                      .clip(CircleShape),
               showPlaceHolder = true)
     }
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.ui.profile.DefaultIconPlaceholder
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
@@ -150,7 +151,7 @@ fun EditableProfilePictureWithImageCropper(
 @Composable
 fun ProfilePicture(
     photo: PhotoUi,
-    imageViewModel: ImageViewModel,
+    imageViewModel: ImageViewModel = viewModel(),
     modifier: Modifier = Modifier,
     imageSize: Dp = 120.dp,
 ) {

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -1,6 +1,5 @@
 package com.android.agrihealth.ui.utils
 
-import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -17,31 +16,21 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.ui.profile.DefaultIconPlaceholder
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.RemotePhotoDisplay
 import com.android.agrihealth.ui.report.AddReportDialogTexts
-import com.mr0xf00.easycrop.CropError
-import com.mr0xf00.easycrop.CropResult
-import com.mr0xf00.easycrop.ImageCropper
-import com.mr0xf00.easycrop.crop
 import com.mr0xf00.easycrop.rememberImageCropper
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * Used to give the [EditableProfilePicture] the photo it must display and it's source (to decide
@@ -73,54 +62,11 @@ object ProfilePictureComponentsTexts {
   const val DIALOG_TITLE = "Error!"
 }
 
-/** To make type more clear */
-typealias ImageCropperLauncher = (Uri) -> Unit
 
-/**
- * Initializes and remembers an image cropper created by default
- *
- * @param imageCropper The supplied [ImageCropper]
- * @param cropMaxSize The maximum size of the crop region. Prefer leaving it as is
- * @param scope The scope at which new coroutines will be created
- * @param onCropSuccess Called when the user succesfully chose and cropped a photo
- * @param onCropError Called when the user chose a picture and tried to crop if but it failed
- * @param onCropCancelled Called when the user cancels the crop (by dismissing the window for
- *   example)
- */
-@Composable
-fun rememberDefaultImageCropperLauncher(
-    imageCropper: ImageCropper,
-    cropMaxSize: IntSize = IntSize(8192, 8192),
-    scope: CoroutineScope,
-    onCropSuccess: (ByteArray) -> Unit,
-    onCropError: (String) -> Unit,
-    onCropCancelled: () -> Unit = {},
-): ImageCropperLauncher {
-  val context = LocalContext.current
-
-  // Not sure what keys to put there (if any at all?)
-  return remember(imageCropper, onCropSuccess, onCropError, onCropCancelled) {
-    { uri: Uri ->
-      scope.launch {
-        val bitmap = uri.toBitmap(context).asImageBitmap()
-        when (val result = imageCropper.crop(cropMaxSize, bmp = bitmap)) {
-          is CropResult.Cancelled -> onCropCancelled()
-          is CropError ->
-              onCropError(
-                  when (result) {
-                    CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
-                    CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
-                  })
-          is CropResult.Success -> onCropSuccess(result.bitmap.toByteArray())
-        }
-      }
-    }
-  }
-}
 
 /**
  * A profile picture is displayed, with a small icon that allows the user to either remove their
- * existing profile picture or add a enw one. When the user clicks on the button when no photo is
+ * existing profile picture or add a new one. When the user clicks on the button when no photo is
  * displayed, the user is asked to upload a photo from either device storage or camera, and then the
  * user is asked to crop the image into a circle (as the profile picture is a circle)
  *
@@ -137,7 +83,7 @@ fun rememberDefaultImageCropperLauncher(
  *   leaving this empty normally
  */
 @Composable
-fun EditableProfilePictureWithUI(
+fun EditableProfilePictureWithImageCropper(
     photo: PhotoUi,
     isEditable: Boolean,
     imageViewModel: ImageViewModel,
@@ -241,7 +187,7 @@ fun ProfilePicture(
  * A profile picture is displayed, with a small icon that allows the user to either remove their
  * existing profile picture or add a enw one. What happens when the user clicks on the button must
  * be defined with [onPhotoPicked] and [onPhotoRemoved] respectfully. Prefer using
- * [EditableProfilePictureWithUI] for photo picker and image cropper support
+ * [EditableProfilePictureWithImageCropper] for photo picker and image cropper support
  *
  * @param photo The picture to display and its source
  * @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one),

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -1,24 +1,46 @@
 package com.android.agrihealth.ui.utils
 
+import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.RemotePhotoDisplay
+import com.android.agrihealth.ui.report.AddReportDialogTexts
+import com.mr0xf00.easycrop.CropError
+import com.mr0xf00.easycrop.CropResult
+import com.mr0xf00.easycrop.ImageCropper
+import com.mr0xf00.easycrop.crop
+import com.mr0xf00.easycrop.rememberImageCropper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 // TODO Write kdoc
 sealed interface PhotoUi {
@@ -27,6 +49,115 @@ sealed interface PhotoUi {
   data class Local(val bytes: ByteArray) : PhotoUi
 }
 
+object ProfilePictureComponentsTestTags {
+  const val PROFILE_PICTURE = "ProfilePicture"
+  const val PROFILE_PICTURE_EDIT_BUTTON = "ProfilePictureEditButton"
+  const val ERROR_DIALOG_OK_BUTTON = "ProfilePictureErrorDialogOkButton"
+  const val ERROR_DIALOG = "ProfilePictureErrorDialog"
+}
+
+object ProfilePictureComponentsTexts {
+  const val DIALOG_LOADING_ERROR = "The supplied image is invalid, not supported, or you don't have the required permissions to read it..."
+  const val DIALOG_SAVING_ERROR = "The result could not be saved. The selected area is likely to big, try selecting a smaller area..."
+  const val DIALOG_TITLE = "Error!"
+}
+
+typealias ImageCropLauncher = (Uri) -> Unit
+
+@Composable
+fun rememberDefaultImageCropLauncher(
+  imageCropper: ImageCropper,
+  cropMaxSize: IntSize = IntSize(4096, 4096),
+  scope: CoroutineScope,
+  onCropSuccess: (ByteArray) -> Unit,
+  onCropError: (String) -> Unit,
+  onCropCancelled: () -> Unit = {},
+): ImageCropLauncher {
+  val context = LocalContext.current
+
+  // Not sure what keys to put there (if any at all?)
+  return remember(imageCropper, onCropSuccess, onCropError, onCropCancelled) {
+    { uri: Uri ->
+      scope.launch {
+        val bitmap = uri.toBitmap(context).asImageBitmap()
+        when (val result = imageCropper.crop(cropMaxSize, bmp = bitmap)) {
+          is CropResult.Cancelled -> onCropCancelled()
+          is CropError -> onCropError(
+            when (result) {
+              CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
+              CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
+            }
+          )
+          is CropResult.Success -> onCropSuccess(result.bitmap.toByteArray())
+        }
+      }
+    }
+  }
+}
+
+
+@Composable
+fun EditableProfilePictureWithUI(
+  photo: PhotoUi,
+  isEditable: Boolean,
+  imageViewModel: ImageViewModel,
+  modifier: Modifier = Modifier,
+  imageSize: Dp = 120.dp,
+  onPhotoPicked: (ByteArray) -> Unit,
+  onPhotoRemoved: () -> Unit,
+  launchImageCropper: ImageCropLauncher? = null,
+) {
+  val scope = rememberCoroutineScope()
+
+  var showImagePicker by rememberSaveable { mutableStateOf(false) }
+  var showErrorDialog by rememberSaveable { mutableStateOf(false) }
+  var errorDialogMessage by rememberSaveable { mutableStateOf("") }
+
+  val imageCropper = rememberImageCropper()
+  val defaultLauncher: ImageCropLauncher = rememberDefaultImageCropLauncher(
+    imageCropper = imageCropper,
+    scope = scope,
+    onCropSuccess = onPhotoPicked,
+    onCropError = { errorMessage ->
+      showErrorDialog = true
+      errorDialogMessage = errorMessage
+    },
+  )
+
+  val effectiveLauncher = launchImageCropper ?: defaultLauncher
+
+  val croppingIsOngoing = imageCropper.cropState != null
+
+  EditableProfilePicture(
+    photo = photo,
+    isEditable = isEditable,
+    imageViewModel = imageViewModel,
+    modifier = modifier,
+    imageSize = imageSize,
+    onPhotoPicked = { showImagePicker = true },
+    onPhotoRemoved = onPhotoRemoved
+  )
+
+  if (showErrorDialog) {
+    ErrorDialog(dialogTitle = ProfilePictureComponentsTexts.DIALOG_TITLE, errorMessage = errorDialogMessage, onDismiss = { showErrorDialog = false })
+  }
+
+  if (croppingIsOngoing) {
+    ShowImageCropperDialog(imageCropper)
+  }
+
+  if (showImagePicker) {
+    ImagePickerDialog(
+      onDismiss = { showImagePicker = false },
+      onImageSelected = { uri ->
+        showImagePicker = false
+        effectiveLauncher(uri)
+      }
+    )
+  }
+}
+
+// TODO Add support for square pictures (so office profile pictures can be square)
 @Composable
 fun EditableProfilePicture(
   photo: PhotoUi,
@@ -34,10 +165,8 @@ fun EditableProfilePicture(
   imageViewModel: ImageViewModel,
   modifier: Modifier = Modifier,
   imageSize: Dp = 120.dp,
-  profilePictureTestTag: String,
-  editButtonTestTag: String,
-  onAddClicked: () -> Unit,
-  onRemoveClicked: () -> Unit,
+  onPhotoPicked: () -> Unit,
+  onPhotoRemoved: () -> Unit,
 ) {
   Box(
     modifier = modifier.size(imageSize),
@@ -47,18 +176,18 @@ fun EditableProfilePicture(
       is PhotoUi.Remote -> RemotePhotoDisplay(
         photoURL = photo.url,
         imageViewModel = imageViewModel,
-        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(profilePictureTestTag),
+        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
         contentDescription = "Photo",
         showPlaceHolder = true
       )
       is PhotoUi.Local -> LocalPhotoDisplay(
         photoByteArray = photo.bytes,
-        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(profilePictureTestTag),
+        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
         showPlaceHolder = true
       )
       PhotoUi.Empty -> LocalPhotoDisplay(
         photoByteArray = null,
-        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(profilePictureTestTag),
+        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
         showPlaceHolder = true
       )
     }
@@ -66,11 +195,11 @@ fun EditableProfilePicture(
     if (isEditable) {
       val removeMode = photo != PhotoUi.Empty
       FloatingActionButton(
-        onClick = { if (removeMode) onRemoveClicked() else onAddClicked() },
+        onClick = { if (removeMode) onPhotoRemoved() else onPhotoPicked() },
         modifier = Modifier
           .size(40.dp)
           .align(Alignment.BottomEnd)
-          .testTag(editButtonTestTag),
+          .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE_EDIT_BUTTON),
         containerColor = MaterialTheme.colorScheme.primaryContainer,
         contentColor = MaterialTheme.colorScheme.onPrimaryContainer
       ) {
@@ -82,4 +211,31 @@ fun EditableProfilePicture(
       }
     }
   }
+}
+
+// TODO: Place this in its own file, as it is a copy of the one in AddReportScreen.kt
+/**
+ * A dialog shown when an error happened and a report couldn't be created
+ *
+ * @param dialogTitle Title of the dialog
+ * @param errorMessage The error message received when attempting to create a report
+ * @param onDismiss Executed when the user dismisses the dialog
+ */
+@Composable
+fun ErrorDialog(dialogTitle: String, errorMessage: String, onDismiss: () -> Unit) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    confirmButton = {
+      TextButton(
+        onClick = onDismiss,
+        modifier = Modifier.testTag(ProfilePictureComponentsTestTags.ERROR_DIALOG_OK_BUTTON),
+        colors =
+          ButtonDefaults.textButtonColors(
+            contentColor = MaterialTheme.colorScheme.onSurface)) {
+        Text(AddReportDialogTexts.OK)
+      }
+    },
+    title = { Text(dialogTitle) },
+    text = { Text(errorMessage) },
+    modifier = Modifier.testTag(ProfilePictureComponentsTestTags.ERROR_DIALOG))
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -43,7 +43,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
- *  Used to give the [EditableProfilePicture] the photo it must display and it's source (to decide how to display it)
+ * Used to give the [EditableProfilePicture] the photo it must display and it's source (to decide
+ * how to display it)
  */
 sealed interface PhotoUi {
   /** An empty profile picture */
@@ -54,9 +55,7 @@ sealed interface PhotoUi {
   data class Local(val bytes: ByteArray) : PhotoUi
 }
 
-/**
- *  The various test tags associated with the components of a profile picture
- */
+/** The various test tags associated with the components of a profile picture */
 object ProfilePictureComponentsTestTags {
   const val PROFILE_PICTURE = "ProfilePicture"
   const val PROFILE_PICTURE_EDIT_BUTTON = "ProfilePictureEditButton"
@@ -64,12 +63,12 @@ object ProfilePictureComponentsTestTags {
   const val ERROR_DIALOG = "ProfilePictureErrorDialog"
 }
 
-/**
- *  The various texts used by the components of a profile picture
- */
+/** The various texts used by the components of a profile picture */
 object ProfilePictureComponentsTexts {
-  const val DIALOG_LOADING_ERROR = "The supplied image is invalid, not supported, or you don't have the required permissions to read it..."
-  const val DIALOG_SAVING_ERROR = "The result could not be saved. The selected area is likely to big, try selecting a smaller area..."
+  const val DIALOG_LOADING_ERROR =
+      "The supplied image is invalid, not supported, or you don't have the required permissions to read it..."
+  const val DIALOG_SAVING_ERROR =
+      "The result could not be saved. The selected area is likely to big, try selecting a smaller area..."
   const val DIALOG_TITLE = "Error!"
 }
 
@@ -77,23 +76,24 @@ object ProfilePictureComponentsTexts {
 typealias ImageCropperLauncher = (Uri) -> Unit
 
 /**
- *  Initializes and remembers an image cropper created by default
+ * Initializes and remembers an image cropper created by default
  *
- *  @param imageCropper The supplied [ImageCropper]
- *  @param cropMaxSize The maximum size of the crop region. Prefer leaving it as is
- *  @param scope The scope at which new coroutines will be created
- *  @param onCropSuccess Called when the user succesfully chose and cropped a photo
- *  @param onCropError Called when the user chose a picture and tried to crop if but it failed
- *  @param onCropCancelled Called when the user cancels the crop (by dismissing the window for example)
+ * @param imageCropper The supplied [ImageCropper]
+ * @param cropMaxSize The maximum size of the crop region. Prefer leaving it as is
+ * @param scope The scope at which new coroutines will be created
+ * @param onCropSuccess Called when the user succesfully chose and cropped a photo
+ * @param onCropError Called when the user chose a picture and tried to crop if but it failed
+ * @param onCropCancelled Called when the user cancels the crop (by dismissing the window for
+ *   example)
  */
 @Composable
 fun rememberDefaultImageCropperLauncher(
-  imageCropper: ImageCropper,
-  cropMaxSize: IntSize = IntSize(8192, 8192),
-  scope: CoroutineScope,
-  onCropSuccess: (ByteArray) -> Unit,
-  onCropError: (String) -> Unit,
-  onCropCancelled: () -> Unit = {},
+    imageCropper: ImageCropper,
+    cropMaxSize: IntSize = IntSize(8192, 8192),
+    scope: CoroutineScope,
+    onCropSuccess: (ByteArray) -> Unit,
+    onCropError: (String) -> Unit,
+    onCropCancelled: () -> Unit = {},
 ): ImageCropperLauncher {
   val context = LocalContext.current
 
@@ -104,12 +104,12 @@ fun rememberDefaultImageCropperLauncher(
         val bitmap = uri.toBitmap(context).asImageBitmap()
         when (val result = imageCropper.crop(cropMaxSize, bmp = bitmap)) {
           is CropResult.Cancelled -> onCropCancelled()
-          is CropError -> onCropError(
-            when (result) {
-              CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
-              CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
-            }
-          )
+          is CropError ->
+              onCropError(
+                  when (result) {
+                    CropError.LoadingError -> ProfilePictureComponentsTexts.DIALOG_LOADING_ERROR
+                    CropError.SavingError -> ProfilePictureComponentsTexts.DIALOG_SAVING_ERROR
+                  })
           is CropResult.Success -> onCropSuccess(result.bitmap.toByteArray())
         }
       }
@@ -117,31 +117,34 @@ fun rememberDefaultImageCropperLauncher(
   }
 }
 
-
 /**
- *  A profile picture is displayed, with a small icon that allows the user to either remove their existing profile picture or add a enw one.
- *  When the user clicks on the button when no photo is displayed, the user is asked to upload a photo from either device storage or camera, and
- *  then the user is asked to crop the image into a circle (as the profile picture is a circle)
+ * A profile picture is displayed, with a small icon that allows the user to either remove their
+ * existing profile picture or add a enw one. When the user clicks on the button when no photo is
+ * displayed, the user is asked to upload a photo from either device storage or camera, and then the
+ * user is asked to crop the image into a circle (as the profile picture is a circle)
  *
- *  @param photo The picture to display and its source
- *  @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one), false to make the profile picture read-only
- *  @param imageViewModel The [ImageViewModel] used to download / upload the remote profile picture
- *  @param modifier A modifier applied to the composable
- *  @param imageSize The size of the profile picture, in [dp]
- *  @param onPhotoPicked Called when the user picked (and cropped) a photo. This lambda contains the chosen photo as an argument
- *  @param onPhotoRemoved Called when the user decides to remove the current profile picture
- *  @param imageCropperLauncher The launcher of the image cropper. Specify one for testing, prefer leaving this empty normally
+ * @param photo The picture to display and its source
+ * @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one),
+ *   false to make the profile picture read-only
+ * @param imageViewModel The [ImageViewModel] used to download / upload the remote profile picture
+ * @param modifier A modifier applied to the composable
+ * @param imageSize The size of the profile picture, in [dp]
+ * @param onPhotoPicked Called when the user picked (and cropped) a photo. This lambda contains the
+ *   chosen photo as an argument
+ * @param onPhotoRemoved Called when the user decides to remove the current profile picture
+ * @param imageCropperLauncher The launcher of the image cropper. Specify one for testing, prefer
+ *   leaving this empty normally
  */
 @Composable
 fun EditableProfilePictureWithUI(
-  photo: PhotoUi,
-  isEditable: Boolean,
-  imageViewModel: ImageViewModel,
-  modifier: Modifier = Modifier,
-  imageSize: Dp = 120.dp,
-  onPhotoPicked: (ByteArray) -> Unit,
-  onPhotoRemoved: () -> Unit,
-  imageCropperLauncher: ImageCropperLauncher? = null,
+    photo: PhotoUi,
+    isEditable: Boolean,
+    imageViewModel: ImageViewModel,
+    modifier: Modifier = Modifier,
+    imageSize: Dp = 120.dp,
+    onPhotoPicked: (ByteArray) -> Unit,
+    onPhotoRemoved: () -> Unit,
+    imageCropperLauncher: ImageCropperLauncher? = null,
 ) {
   val scope = rememberCoroutineScope()
 
@@ -150,32 +153,35 @@ fun EditableProfilePictureWithUI(
   var errorDialogMessage by rememberSaveable { mutableStateOf("") }
 
   val imageCropper = rememberImageCropper()
-  val defaultLauncher: ImageCropperLauncher = rememberDefaultImageCropperLauncher(
-    imageCropper = imageCropper,
-    scope = scope,
-    onCropSuccess = onPhotoPicked,
-    onCropError = { errorMessage ->
-      showErrorDialog = true
-      errorDialogMessage = errorMessage
-    },
-  )
+  val defaultLauncher: ImageCropperLauncher =
+      rememberDefaultImageCropperLauncher(
+          imageCropper = imageCropper,
+          scope = scope,
+          onCropSuccess = onPhotoPicked,
+          onCropError = { errorMessage ->
+            showErrorDialog = true
+            errorDialogMessage = errorMessage
+          },
+      )
 
   val effectiveLauncher = imageCropperLauncher ?: defaultLauncher
 
   val croppingIsOngoing = imageCropper.cropState != null
 
   EditableProfilePicture(
-    photo = photo,
-    isEditable = isEditable,
-    imageViewModel = imageViewModel,
-    modifier = modifier,
-    imageSize = imageSize,
-    onPhotoPicked = { showImagePicker = true },
-    onPhotoRemoved = onPhotoRemoved
-  )
+      photo = photo,
+      isEditable = isEditable,
+      imageViewModel = imageViewModel,
+      modifier = modifier,
+      imageSize = imageSize,
+      onPhotoPicked = { showImagePicker = true },
+      onPhotoRemoved = onPhotoRemoved)
 
   if (showErrorDialog) {
-    ErrorDialog(dialogTitle = ProfilePictureComponentsTexts.DIALOG_TITLE, errorMessage = errorDialogMessage, onDismiss = { showErrorDialog = false })
+    ErrorDialog(
+        dialogTitle = ProfilePictureComponentsTexts.DIALOG_TITLE,
+        errorMessage = errorDialogMessage,
+        onDismiss = { showErrorDialog = false })
   }
 
   if (croppingIsOngoing) {
@@ -184,81 +190,89 @@ fun EditableProfilePictureWithUI(
 
   if (showImagePicker) {
     ImagePickerDialog(
-      onDismiss = { showImagePicker = false },
-      onImageSelected = { uri ->
-        showImagePicker = false
-        effectiveLauncher(uri)
-      }
-    )
+        onDismiss = { showImagePicker = false },
+        onImageSelected = { uri ->
+          showImagePicker = false
+          effectiveLauncher(uri)
+        })
   }
 }
 
-
 /**
- *  A profile picture is displayed, with a small icon that allows the user to either remove their existing profile picture or add a enw one.
- *  What happens when the user clicks on the button must be defined with [onPhotoPicked] and [onPhotoRemoved] respectfully.
- *  Prefer using [EditableProfilePictureWithUI] for photo picker and image cropper support
+ * A profile picture is displayed, with a small icon that allows the user to either remove their
+ * existing profile picture or add a enw one. What happens when the user clicks on the button must
+ * be defined with [onPhotoPicked] and [onPhotoRemoved] respectfully. Prefer using
+ * [EditableProfilePictureWithUI] for photo picker and image cropper support
  *
- *  @param photo The picture to display and its source
- *  @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one), false to make the profile picture read-only
- *  @param imageViewModel The [ImageViewModel] used to download / upload the remote profile picture
- *  @param modifier A modifier applied to the composable
- *  @param imageSize The size of the profile picture, in [dp]
- *  @param onPhotoPicked Called when the user picked (and cropped) a photo. This lambda contains the chosen photo as an argument
- *  @param onPhotoRemoved Called when the user decides to remove the current profile picture
+ * @param photo The picture to display and its source
+ * @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one),
+ *   false to make the profile picture read-only
+ * @param imageViewModel The [ImageViewModel] used to download / upload the remote profile picture
+ * @param modifier A modifier applied to the composable
+ * @param imageSize The size of the profile picture, in [dp]
+ * @param onPhotoPicked Called when the user picked (and cropped) a photo. This lambda contains the
+ *   chosen photo as an argument
+ * @param onPhotoRemoved Called when the user decides to remove the current profile picture
  */
 // TODO Add support for square pictures (so office profile pictures can be square)
 @Composable
 fun EditableProfilePicture(
-  photo: PhotoUi,
-  isEditable: Boolean,
-  imageViewModel: ImageViewModel,
-  modifier: Modifier = Modifier,
-  imageSize: Dp = 120.dp,
-  onPhotoPicked: () -> Unit,
-  onPhotoRemoved: () -> Unit,
+    photo: PhotoUi,
+    isEditable: Boolean,
+    imageViewModel: ImageViewModel,
+    modifier: Modifier = Modifier,
+    imageSize: Dp = 120.dp,
+    onPhotoPicked: () -> Unit,
+    onPhotoRemoved: () -> Unit,
 ) {
   Box(
-    modifier = modifier.size(imageSize),
-    contentAlignment = Alignment.Center,
+      modifier = modifier.size(imageSize),
+      contentAlignment = Alignment.Center,
   ) {
     when (photo) {
-      is PhotoUi.Remote -> RemotePhotoDisplay(
-        photoURL = photo.url,
-        imageViewModel = imageViewModel,
-        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
-        contentDescription = "Photo",
-        showPlaceHolder = true
-      )
-      is PhotoUi.Local -> LocalPhotoDisplay(
-        photoByteArray = photo.bytes,
-        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
-        showPlaceHolder = true
-      )
-      PhotoUi.Empty -> LocalPhotoDisplay(
-        photoByteArray = null,
-        modifier = Modifier.size(imageSize).clip(CircleShape).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
-        showPlaceHolder = true
-      )
+      is PhotoUi.Remote ->
+          RemotePhotoDisplay(
+              photoURL = photo.url,
+              imageViewModel = imageViewModel,
+              modifier =
+                  Modifier.size(imageSize)
+                      .clip(CircleShape)
+                      .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
+              contentDescription = "Photo",
+              showPlaceHolder = true)
+      is PhotoUi.Local ->
+          LocalPhotoDisplay(
+              photoByteArray = photo.bytes,
+              modifier =
+                  Modifier.size(imageSize)
+                      .clip(CircleShape)
+                      .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
+              showPlaceHolder = true)
+      PhotoUi.Empty ->
+          LocalPhotoDisplay(
+              photoByteArray = null,
+              modifier =
+                  Modifier.size(imageSize)
+                      .clip(CircleShape)
+                      .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
+              showPlaceHolder = true)
     }
 
     if (isEditable) {
       val removeMode = photo != PhotoUi.Empty
       FloatingActionButton(
-        onClick = { if (removeMode) onPhotoRemoved() else onPhotoPicked() },
-        modifier = Modifier
-          .size(40.dp)
-          .align(Alignment.BottomEnd)
-          .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE_EDIT_BUTTON),
-        containerColor = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-      ) {
-        Icon(
-          imageVector = if (removeMode) Icons.Default.Clear else Icons.Default.CameraAlt,
-          contentDescription = if (removeMode) "Remove photo" else "Add photo",
-          modifier = Modifier.size(20.dp)
-        )
-      }
+          onClick = { if (removeMode) onPhotoRemoved() else onPhotoPicked() },
+          modifier =
+              Modifier.size(40.dp)
+                  .align(Alignment.BottomEnd)
+                  .testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE_EDIT_BUTTON),
+          containerColor = MaterialTheme.colorScheme.primaryContainer,
+          contentColor = MaterialTheme.colorScheme.onPrimaryContainer) {
+            Icon(
+                imageVector = if (removeMode) Icons.Default.Clear else Icons.Default.CameraAlt,
+                contentDescription = if (removeMode) "Remove photo" else "Add photo",
+                modifier = Modifier.size(20.dp))
+          }
     }
   }
 }
@@ -274,18 +288,18 @@ fun EditableProfilePicture(
 @Composable
 fun ErrorDialog(dialogTitle: String, errorMessage: String, onDismiss: () -> Unit) {
   AlertDialog(
-    onDismissRequest = onDismiss,
-    confirmButton = {
-      TextButton(
-        onClick = onDismiss,
-        modifier = Modifier.testTag(ProfilePictureComponentsTestTags.ERROR_DIALOG_OK_BUTTON),
-        colors =
-          ButtonDefaults.textButtonColors(
-            contentColor = MaterialTheme.colorScheme.onSurface)) {
-        Text(AddReportDialogTexts.OK)
-      }
-    },
-    title = { Text(dialogTitle) },
-    text = { Text(errorMessage) },
-    modifier = Modifier.testTag(ProfilePictureComponentsTestTags.ERROR_DIALOG))
+      onDismissRequest = onDismiss,
+      confirmButton = {
+        TextButton(
+            onClick = onDismiss,
+            modifier = Modifier.testTag(ProfilePictureComponentsTestTags.ERROR_DIALOG_OK_BUTTON),
+            colors =
+                ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onSurface)) {
+              Text(AddReportDialogTexts.OK)
+            }
+      },
+      title = { Text(dialogTitle) },
+      text = { Text(errorMessage) },
+      modifier = Modifier.testTag(ProfilePictureComponentsTestTags.ERROR_DIALOG))
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -62,8 +62,6 @@ object ProfilePictureComponentsTexts {
   const val DIALOG_TITLE = "Error!"
 }
 
-
-
 /**
  * A profile picture is displayed, with a small icon that allows the user to either remove their
  * existing profile picture or add a new one. When the user clicks on the button when no photo is
@@ -146,40 +144,35 @@ fun EditableProfilePictureWithImageCropper(
 }
 
 /**
- *  A profile picture. It will fetch the photo on the repository, or show the local
- *  photo, or show a default profile picture icon if no photo is given
+ * A profile picture. It will fetch the photo on the repository, or show the local photo, or show a
+ * default profile picture icon if no photo is given
  *
- *  @param photo A [PhotoUi] that stores the photo and its source (on the repository or local)
- *  @param imageViewModel The [ImageViewModel] used to display the photo
- *  @param modifier The [Modifier] used to customize the profile picture
- *  @param imageSize The size of the image in [Dp]
+ * @param photo A [PhotoUi] that stores the photo and its source (on the repository or local)
+ * @param imageViewModel The [ImageViewModel] used to display the photo
+ * @param modifier The [Modifier] used to customize the profile picture
+ * @param imageSize The size of the image in [Dp]
  */
 @Composable
 fun ProfilePicture(
-  photo: PhotoUi,
-  imageViewModel: ImageViewModel,
-  modifier: Modifier = Modifier,
-  imageSize: Dp = 120.dp,
+    photo: PhotoUi,
+    imageViewModel: ImageViewModel,
+    modifier: Modifier = Modifier,
+    imageSize: Dp = 120.dp,
 ) {
   when (photo) {
     is PhotoUi.Remote ->
-      RemotePhotoDisplay(
-        photoURL = photo.url,
-        imageViewModel = imageViewModel,
-        modifier =
-          modifier.size(imageSize)
-            .clip(CircleShape),
-        contentDescription = "Photo",
-        showPlaceHolder = true)
+        RemotePhotoDisplay(
+            photoURL = photo.url,
+            imageViewModel = imageViewModel,
+            modifier = modifier.size(imageSize).clip(CircleShape),
+            contentDescription = "Photo",
+            showPlaceHolder = true)
     is PhotoUi.Local ->
-      LocalPhotoDisplay(
-        photoByteArray = photo.bytes,
-        modifier =
-          Modifier.size(imageSize)
-            .clip(CircleShape),
-        showPlaceHolder = true)
-    PhotoUi.Empty ->
-      DefaultIconPlaceholder(Modifier.size(imageSize).clip(CircleShape))
+        LocalPhotoDisplay(
+            photoByteArray = photo.bytes,
+            modifier = Modifier.size(imageSize).clip(CircleShape),
+            showPlaceHolder = true)
+    PhotoUi.Empty -> DefaultIconPlaceholder(Modifier.size(imageSize).clip(CircleShape))
   }
 }
 
@@ -213,13 +206,7 @@ fun EditableProfilePicture(
       modifier = modifier.size(imageSize).testTag(ProfilePictureComponentsTestTags.PROFILE_PICTURE),
       contentAlignment = Alignment.Center,
   ) {
-
-    ProfilePicture(
-      photo,
-      imageViewModel,
-      Modifier,
-      imageSize
-    )
+    ProfilePicture(photo, imageViewModel, Modifier, imageSize)
 
     if (isEditable) {
       val removeMode = photo != PhotoUi.Empty

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -185,7 +185,7 @@ fun ProfilePicture(
 
 /**
  * A profile picture is displayed, with a small icon that allows the user to either remove their
- * existing profile picture or add a enw one. What happens when the user clicks on the button must
+ * existing profile picture or add a new one. What happens when the user clicks on the button must
  * be defined with [onPhotoPicked] and [onPhotoRemoved] respectfully. Prefer using
  * [EditableProfilePictureWithImageCropper] for photo picker and image cropper support
  *
@@ -199,7 +199,6 @@ fun ProfilePicture(
  *   chosen photo as an argument
  * @param onPhotoRemoved Called when the user decides to remove the current profile picture
  */
-// TODO Add support for square pictures (so office profile pictures can be square)
 @Composable
 fun EditableProfilePicture(
     photo: PhotoUi,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -77,8 +77,6 @@ object ProfilePictureComponentsTexts {
  * @param onPhotoPicked Called when the user picked (and cropped) a photo. This lambda contains the
  *   chosen photo as an argument
  * @param onPhotoRemoved Called when the user decides to remove the current profile picture
- * @param imageCropperLauncher The launcher of the image cropper. Specify one for testing, prefer
- *   leaving this empty normally
  */
 @Composable
 fun EditableProfilePictureWithImageCropper(
@@ -89,7 +87,6 @@ fun EditableProfilePictureWithImageCropper(
     imageSize: Dp = 120.dp,
     onPhotoPicked: (ByteArray) -> Unit,
     onPhotoRemoved: () -> Unit,
-    imageCropperLauncher: ImageCropperLauncher? = null,
 ) {
   val scope = rememberCoroutineScope()
 
@@ -98,7 +95,7 @@ fun EditableProfilePictureWithImageCropper(
   var errorDialogMessage by rememberSaveable { mutableStateOf("") }
 
   val imageCropper = rememberImageCropper()
-  val defaultLauncher: ImageCropperLauncher =
+  val imageCropperLauncher: ImageCropperLauncher =
       rememberDefaultImageCropperLauncher(
           imageCropper = imageCropper,
           scope = scope,
@@ -108,8 +105,6 @@ fun EditableProfilePictureWithImageCropper(
             errorDialogMessage = errorMessage
           },
       )
-
-  val effectiveLauncher = imageCropperLauncher ?: defaultLauncher
 
   val croppingIsOngoing = imageCropper.cropState != null
 
@@ -138,7 +133,7 @@ fun EditableProfilePictureWithImageCropper(
         onDismiss = { showImagePicker = false },
         onImageSelected = { uri ->
           showImagePicker = false
-          effectiveLauncher(uri)
+          imageCropperLauncher(uri)
         })
   }
 }

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -272,7 +272,7 @@ fun EditableProfilePicture(
     ProfilePicture(
       photo,
       imageViewModel,
-      modifier.size(imageSize).clip(CircleShape),
+      Modifier,
       imageSize
     )
 

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -119,7 +119,9 @@ fun rememberDefaultImageCropperLauncher(
 
 
 /**
- *  A profile picture is displayed, with a small icon that allows the user to either remove their existing profile picture or add a enw one
+ *  A profile picture is displayed, with a small icon that allows the user to either remove their existing profile picture or add a enw one.
+ *  When the user clicks on the button when no photo is displayed, the user is asked to upload a photo from either device storage or camera, and
+ *  then the user is asked to crop the image into a circle (as the profile picture is a circle)
  *
  *  @param photo The picture to display and its source
  *  @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one), false to make the profile picture read-only
@@ -191,8 +193,11 @@ fun EditableProfilePictureWithUI(
   }
 }
 
+
 /**
- *  A profile picture is displayed, with a small icon that allows the user to either remove their existing profile picture or add a enw one
+ *  A profile picture is displayed, with a small icon that allows the user to either remove their existing profile picture or add a enw one.
+ *  What happens when the user clicks on the button must be defined with [onPhotoPicked] and [onPhotoRemoved] respectfully.
+ *  Prefer using [EditableProfilePictureWithUI] for photo picker and image cropper support
  *
  *  @param photo The picture to display and its source
  *  @param isEditable true to allow the user to edit the displayed photo (i.e remove it or add one), false to make the profile picture read-only

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/utils/ProfilePictureComponents.kt
@@ -29,7 +29,6 @@ import com.android.agrihealth.data.model.images.ImageViewModel
 import com.android.agrihealth.ui.profile.DefaultIconPlaceholder
 import com.android.agrihealth.ui.profile.LocalPhotoDisplay
 import com.android.agrihealth.ui.profile.RemotePhotoDisplay
-import com.android.agrihealth.ui.report.AddReportDialogTexts
 import com.mr0xf00.easycrop.rememberImageCropper
 
 /**
@@ -60,6 +59,7 @@ object ProfilePictureComponentsTexts {
   const val DIALOG_SAVING_ERROR =
       "The result could not be saved. The selected area is likely to big, try selecting a smaller area..."
   const val DIALOG_TITLE = "Error!"
+  const val ERROR_DIALOG_OK = "Ok"
 }
 
 /**
@@ -241,7 +241,7 @@ fun ErrorDialog(dialogTitle: String, errorMessage: String, onDismiss: () -> Unit
             colors =
                 ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.onSurface)) {
-              Text(AddReportDialogTexts.OK)
+              Text(ProfilePictureComponentsTexts.ERROR_DIALOG_OK)
             }
       },
       title = { Text(dialogTitle) },

--- a/AgriHealth-Alert-main/firebase-functions/package-lock.json
+++ b/AgriHealth-Alert-main/firebase-functions/package-lock.json
@@ -24,7 +24,6 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -40,7 +39,6 @@
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -83,7 +81,6 @@
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
@@ -101,7 +98,6 @@
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -119,7 +115,6 @@
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -130,7 +125,6 @@
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -145,7 +139,6 @@
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -164,7 +157,6 @@
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -175,7 +167,6 @@
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -186,7 +177,6 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -197,7 +187,6 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -208,7 +197,6 @@
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -223,7 +211,6 @@
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.5"
       },
@@ -240,7 +227,6 @@
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -254,7 +240,6 @@
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -268,7 +253,6 @@
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -282,7 +266,6 @@
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -299,7 +282,6 @@
       "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -316,7 +298,6 @@
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -330,7 +311,6 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -344,7 +324,6 @@
       "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -361,7 +340,6 @@
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -375,7 +353,6 @@
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -389,7 +366,6 @@
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -403,7 +379,6 @@
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -417,7 +392,6 @@
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -431,7 +405,6 @@
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -445,7 +418,6 @@
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -462,7 +434,6 @@
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -479,7 +450,6 @@
       "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -496,7 +466,6 @@
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -512,7 +481,6 @@
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -532,7 +500,6 @@
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -546,8 +513,7 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",
@@ -556,7 +522,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
@@ -569,7 +534,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -581,7 +545,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -924,7 +887,6 @@
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -943,7 +905,6 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -957,7 +918,6 @@
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -974,7 +934,6 @@
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -992,7 +951,6 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -1003,7 +961,6 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -1018,7 +975,6 @@
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1033,7 +989,6 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -1047,7 +1002,6 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -1064,7 +1018,6 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -1078,7 +1031,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1089,7 +1041,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1100,7 +1051,6 @@
       "integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -1119,7 +1069,6 @@
       "integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/pattern": "30.0.1",
@@ -1168,7 +1117,6 @@
       "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -1179,7 +1127,6 @@
       "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.2.0",
         "@jest/types": "30.2.0",
@@ -1196,7 +1143,6 @@
       "integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "30.2.0",
         "jest-snapshot": "30.2.0"
@@ -1211,7 +1157,6 @@
       "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -1225,7 +1170,6 @@
       "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@sinonjs/fake-timers": "^13.0.0",
@@ -1244,7 +1188,6 @@
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -1255,7 +1198,6 @@
       "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/expect": "30.2.0",
@@ -1272,7 +1214,6 @@
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -1287,7 +1228,6 @@
       "integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "30.2.0",
@@ -1331,7 +1271,6 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -1345,7 +1284,6 @@
       "integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "chalk": "^4.1.2",
@@ -1362,7 +1300,6 @@
       "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "callsites": "^3.1.0",
@@ -1378,7 +1315,6 @@
       "integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/types": "30.2.0",
@@ -1395,7 +1331,6 @@
       "integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.2.0",
         "graceful-fs": "^4.2.11",
@@ -1412,7 +1347,6 @@
       "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -1440,7 +1374,6 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -1460,7 +1393,6 @@
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1472,7 +1404,6 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1484,7 +1415,6 @@
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1494,8 +1424,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -1503,7 +1432,6 @@
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1527,7 +1455,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -1589,7 +1516,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1600,7 +1526,6 @@
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
@@ -1677,8 +1602,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
       "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1686,7 +1610,6 @@
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1697,7 +1620,6 @@
       "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -1719,7 +1641,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1730,7 +1651,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -1745,7 +1665,6 @@
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -1756,7 +1675,6 @@
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -1768,7 +1686,6 @@
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -1843,8 +1760,7 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
@@ -1852,7 +1768,6 @@
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -1863,7 +1778,6 @@
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -1973,8 +1887,7 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -1989,7 +1902,6 @@
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1999,8 +1911,7 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2021,8 +1932,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -2036,8 +1946,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -2051,8 +1960,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -2066,8 +1974,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -2081,8 +1988,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -2096,8 +2002,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -2111,8 +2016,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -2126,8 +2030,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -2141,8 +2044,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -2156,8 +2058,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -2171,8 +2072,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -2186,8 +2086,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -2201,8 +2100,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -2216,8 +2114,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -2231,8 +2128,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -2244,7 +2140,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -2264,8 +2159,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -2279,8 +2173,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -2294,8 +2187,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2329,6 +2221,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2379,7 +2272,6 @@
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -2396,7 +2288,6 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2436,7 +2327,6 @@
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2491,7 +2381,6 @@
       "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
@@ -2514,7 +2403,6 @@
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -2535,7 +2423,6 @@
       "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/babel__core": "^7.20.5"
       },
@@ -2549,7 +2436,6 @@
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -2577,7 +2463,6 @@
       "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "30.2.0",
         "babel-preset-current-node-syntax": "^1.2.0"
@@ -2623,7 +2508,6 @@
       "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -2694,7 +2578,6 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -2743,7 +2626,6 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -2759,8 +2641,7 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2816,7 +2697,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2840,8 +2720,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0",
-      "peer": true
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2866,7 +2745,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2883,7 +2761,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2893,8 +2770,7 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.1.tgz",
       "integrity": "sha512-+CmxIZ/L2vNcEfvNtLdU0ZQ6mbq3FZnwAP2PPTiKP+1QOoKwlKlPgb8UKV0Dds7QVaMnHm+FwSft2VB0s/SLjQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2957,7 +2833,6 @@
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -2968,8 +2843,7 @@
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3037,8 +2911,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.1",
@@ -3106,7 +2979,6 @@
       "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -3129,7 +3001,6 @@
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3169,7 +3040,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3219,8 +3089,7 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3242,8 +3111,7 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
       "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -3251,7 +3119,6 @@
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3264,8 +3131,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3292,7 +3158,6 @@
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3379,6 +3244,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3496,7 +3362,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3576,7 +3441,6 @@
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -3600,8 +3464,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/exit-x": {
       "version": "0.2.2",
@@ -3609,7 +3472,6 @@
       "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -3620,7 +3482,6 @@
       "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.2.0",
         "@jest/get-type": "30.1.0",
@@ -3778,7 +3639,6 @@
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -3802,7 +3662,6 @@
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3865,6 +3724,7 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
       "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "1.0.8",
@@ -3889,6 +3749,7 @@
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
       "integrity": "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "^4.17.21",
@@ -3954,7 +3815,6 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -4020,7 +3880,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -4093,7 +3952,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4138,7 +3996,6 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4162,7 +4019,6 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4176,7 +4032,6 @@
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4211,7 +4066,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4222,7 +4076,6 @@
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4332,8 +4185,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4428,8 +4280,7 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -4501,7 +4352,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -4551,7 +4401,6 @@
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -4608,8 +4457,7 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4637,7 +4485,6 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4661,7 +4508,6 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4702,7 +4548,6 @@
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4713,7 +4558,6 @@
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -4731,7 +4575,6 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4745,7 +4588,6 @@
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -4761,7 +4603,6 @@
       "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
@@ -4777,7 +4618,6 @@
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -4792,7 +4632,6 @@
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -4837,7 +4676,6 @@
       "integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "execa": "^5.1.1",
         "jest-util": "30.2.0",
@@ -4853,7 +4691,6 @@
       "integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/expect": "30.2.0",
@@ -4886,7 +4723,6 @@
       "integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/test-result": "30.2.0",
@@ -4920,7 +4756,6 @@
       "integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
@@ -4973,7 +4808,6 @@
       "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
         "@jest/get-type": "30.1.0",
@@ -4990,7 +4824,6 @@
       "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-newline": "^3.1.0"
       },
@@ -5004,7 +4837,6 @@
       "integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.2.0",
@@ -5022,7 +4854,6 @@
       "integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/fake-timers": "30.2.0",
@@ -5042,7 +4873,6 @@
       "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -5068,7 +4898,6 @@
       "integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "pretty-format": "30.2.0"
@@ -5083,7 +4912,6 @@
       "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -5100,7 +4928,6 @@
       "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.2.0",
@@ -5122,7 +4949,6 @@
       "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -5138,7 +4964,6 @@
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -5157,7 +4982,6 @@
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -5168,7 +4992,6 @@
       "integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
@@ -5189,7 +5012,6 @@
       "integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-regex-util": "30.0.1",
         "jest-snapshot": "30.2.0"
@@ -5204,7 +5026,6 @@
       "integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.2.0",
         "@jest/environment": "30.2.0",
@@ -5239,7 +5060,6 @@
       "integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.2.0",
         "@jest/fake-timers": "30.2.0",
@@ -5274,7 +5094,6 @@
       "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -5308,7 +5127,6 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5322,7 +5140,6 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -5341,7 +5158,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5355,7 +5171,6 @@
       "integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.2.0",
@@ -5374,7 +5189,6 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5388,7 +5202,6 @@
       "integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5409,7 +5222,6 @@
       "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -5427,7 +5239,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5452,8 +5263,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -5474,7 +5284,6 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -5504,8 +5313,7 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5527,7 +5335,6 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5646,7 +5453,6 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5675,8 +5481,7 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -5775,7 +5580,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -5814,7 +5618,6 @@
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -5831,7 +5634,6 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5845,7 +5647,6 @@
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -5882,8 +5683,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -5900,7 +5700,6 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -5949,7 +5748,6 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5973,7 +5771,6 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -5990,7 +5787,6 @@
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "napi-postinstall": "lib/cli.js"
       },
@@ -6052,16 +5848,14 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6069,7 +5863,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6080,7 +5873,6 @@
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -6147,7 +5939,6 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -6214,7 +6005,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6224,8 +6014,7 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6246,7 +6035,6 @@
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -6305,7 +6093,6 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -6322,8 +6109,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -6336,8 +6122,7 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6345,7 +6130,6 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6359,7 +6143,6 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -6370,7 +6153,6 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -6384,7 +6166,6 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -6399,7 +6180,6 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -6413,7 +6193,6 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -6430,7 +6209,6 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -6454,7 +6232,6 @@
       "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -6470,7 +6247,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6553,8 +6329,7 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.13.0",
@@ -6621,8 +6396,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -6655,7 +6429,6 @@
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -6669,7 +6442,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6815,7 +6587,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7002,7 +6773,6 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -7016,7 +6786,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7027,7 +6796,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7038,7 +6806,6 @@
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7049,8 +6816,7 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -7058,7 +6824,6 @@
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -7072,7 +6837,6 @@
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7119,7 +6883,6 @@
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
@@ -7134,7 +6897,6 @@
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -7154,7 +6916,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7169,8 +6930,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -7178,7 +6938,6 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7192,7 +6951,6 @@
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -7223,7 +6981,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7237,7 +6994,6 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7248,7 +7004,6 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7305,7 +7060,6 @@
       "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.9"
       },
@@ -7380,7 +7134,6 @@
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -7397,7 +7150,6 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7425,8 +7177,7 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7434,7 +7185,6 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -7490,7 +7240,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7543,7 +7292,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -7592,7 +7340,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -7649,7 +7396,6 @@
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -7674,7 +7420,6 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -7752,7 +7497,6 @@
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -7772,7 +7516,6 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7790,8 +7533,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
@@ -7799,7 +7541,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7815,7 +7556,6 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7829,7 +7569,6 @@
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7843,7 +7582,6 @@
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -7867,7 +7605,6 @@
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -7891,8 +7628,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/AgriHealth-Alert-main/gradle/libs.versions.toml
+++ b/AgriHealth-Alert-main/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.2"
+easycrop = "0.1.1"
 kotlin = "2.0.21"
 kotlin-compose = "2.0.21"   # Same version
 coreKtx = "1.12.0"
@@ -40,6 +41,7 @@ mockkAndroid = "1.13.7"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 
+easycrop = { module = "io.github.mr0xf00:easycrop", version.ref = "easycrop" }
 firebase-auth = { module = "com.google.firebase:firebase-auth", version.ref = "firebaseAuth" }
 firebase-database = { module = "com.google.firebase:firebase-database", version.ref = "firebaseDatabase" }
 firebase-firestore = { module = "com.google.firebase:firebase-firestore", version.ref = "firebaseFirestore" }

--- a/AgriHealth-Alert-main/settings.gradle.kts
+++ b/AgriHealth-Alert-main/settings.gradle.kts
@@ -20,6 +20,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { setUrl("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
### #168 Profile Images for Users
---
#### Summary
- Allow users (vets and farmers) to upload a profile picture
- Add an image cropper to allow user to choose the part of the picture to use
- Modify design of ManageOfficeScreen.kt to look similarly to EditProfile Screen (and also add image cropper)
### Information for the team.
---
#### Important Changes
- Add an editable profile picture component
- Make use of the Easycrop library (https://github.com/mr0xf00/easycrop) for image cropping
- Add a photoURL field to the users
- Refactor ImageViewModel to accept a ByteArray as well as Uri. 
- Refactor PhotoComponents to accept a ByteArray as well as a Uri
#### Solved issue
- Solves #168 
### Information for the reviewer.
---
#### How to test changes.
1. Go on the edit profile screen and click on the camera icon to add a photo either from device storage or from camera. Then crop the photo as you see fit.
2. Try cancelling the process at any point (in the dialog that asks for device storage or camera, or in the image cropper) to test the robustness of the profile
3. See that the photo is now in place of the default profile icon. Then click on save changes and wait for a bit (about 10 seconds) until the profile picture reloads.
4. Now go see the profile of this users from elsewhere and see that the profile picture is displayed, for exampling by clicking on Manage Office and then on the name of the user
5. Now go back to the edit profile screen and click on the cross icon to remove the picture. Click on save changes and see that it is now back to the default icon (here and when viewing the profile elsewhere.
6. Test the robustness of the screen by leaving the screen with changes but without saving to see that the changes are actually discarded
7. Now go to the manage Office screen and see that is behaves similarly to the EditProfileScreen
#### Additional Notes.
- The readme.md of the Easycrop  library is *NOT* up-to-date. The suggested way to use the library is wrong, some of the functions used do not exist
- Adding profile pciture support for ManageOfficeScreen and EditProfileScreen should have been one PR instead of two, to avoid 2 different designs. Also the image cropper should have been a PR by itself as it required searching for a suitable library, testing it, and writing utils... It was a lot of work!