### PR TITLE
hotfix/Fix CI device timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,15 @@ jobs:
 
       - name: Run tests
         run: ./gradlew check --parallel --build-cache
+
+      - name: Free up disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/swift
+          sudo apt-get clean
+          df -h
           
       - name: Run instrumentation tests
         timeout-minutes: 60
@@ -91,6 +100,7 @@ jobs:
           target: google_apis
           arch: x86_64
           avd-name: github
+          disk-size: 4096M
           working-directory: ./AgriHealth-Alert-main
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400


### PR DESCRIPTION


### #398 Fix CI device timeout
---
#### Summary
- Fixes the CI timing out when starting the emulated Android device
- Makes the CI way more reliable
### Information for the team.
---
#### How to test changes.
- Start a GitHub action
- Check that it consistently gets to the "Run instrumentation tests" step
#### Implementation details.
- This is because of disk space stuff, so we clean up the CI's useless files before starting tests
#### Additional Notes.
- Shamelessly stolen from @FrancoAdam with his approval