### PR TITLE
Move edit button to profile pictures

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/profile/ProfileScreen.kt
@@ -120,26 +120,30 @@ fun ProfileScreen(
               HorizontalDivider(modifier = Modifier.padding(bottom = 24.dp))
 
               // Profile Image Placeholder
-              Icon(
-                  imageVector =
-                      Icons.Default.AccountCircle, // To change to actual image when available
-                  contentDescription = "Profile Picture",
-                  modifier = Modifier.size(120.dp).clip(CircleShape).testTag(PROFILE_IMAGE),
-                  tint = MaterialTheme.colorScheme.primary)
+              Box(modifier = Modifier, contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector =
+                        Icons.Default.AccountCircle, // To change to actual image when available
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.size(120.dp).clip(CircleShape).testTag(PROFILE_IMAGE),
+                    tint = MaterialTheme.colorScheme.primary)
+                FloatingActionButton(
+                    onClick = onEditProfile,
+                    modifier = Modifier.testTag(EDIT_BUTTON).size(40.dp).align(Alignment.BottomEnd),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer) {
+                      Icon(Icons.Default.Edit, contentDescription = "Edit profile")
+                    }
+              }
 
               Spacer(modifier = Modifier.height(8.dp))
 
               // Name + Edit Icon
               Row(verticalAlignment = Alignment.CenterVertically) {
-                Spacer(
-                    modifier = Modifier.width(32.dp)) // Solution to center the name with edit icon
                 Text(
                     text = "${user.firstname} ${user.lastname}",
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.testTag(NAME_TEXT))
-                IconButton(onClick = onEditProfile, modifier = Modifier.testTag(EDIT_BUTTON)) {
-                  Icon(Icons.Default.Edit, contentDescription = "Edit profile")
-                }
               }
 
               // Description


### PR DESCRIPTION
### #326 Move edit button to profile pictures
---
#### Summary
- Moves the edit button from next to the name to under the profile picture, which is a work around names that are too long and is analogous to the button on edit profile to change profile pictures.
### Information for the reviewer.
---
#### How to test changes.
- Open the profile and check that this loogs to you or not.
#### Implementation details.
- Copied the implementation from @Amerilla to keep coherence in the app. 
