### PR TITLE
Fix UI not refreshing when claiming

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/report/ReportViewViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/report/ReportViewViewModel.kt
@@ -62,8 +62,8 @@ class ReportViewViewModel(
   val saveCompleted: StateFlow<Boolean> = _saveCompleted.asStateFlow()
 
   /** Loads a report by its ID and updates the state. */
-  fun loadReport(reportID: String) {
-    if (_uiState.value.report.id == "RPT001") {
+  fun loadReport(reportID: String, force: Boolean = false) {
+    if (_uiState.value.report.id == "RPT001" || force) {
       viewModelScope.launch {
         _uiState.withLoadingState(
             applyLoading = { state, loading -> state.copy(isLoading = loading) }) {
@@ -163,7 +163,7 @@ class ReportViewViewModel(
       repository.assignReportToVet(reportId, vetId)
 
       // Refresh state after assignment
-      loadReport(reportId)
+      loadReport(reportId, true)
     }
   }
 
@@ -178,7 +178,7 @@ class ReportViewViewModel(
       repository.unassignReport(reportId)
 
       // Refresh state after unassignment
-      loadReport(reportId)
+      loadReport(reportId, true)
     }
   }
 }


### PR DESCRIPTION
### #420 Fix UI not refreshing when claiming
---
#### Summary
- When claiming a report, the UI updates to let you type an answer.
- this improves user flow.
### Information for the reviewer.
---
#### How to test changes.
- Try to assign or unassign yourself on a report.
#### Implementation details.
- added a boolean to allow backend calls to force the report reload.
#### Additional Notes.
- funny number.
