### PR TITLE
BugFix failing MapTest.spiderifyReportsTest()

### DIFF
--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/map/MapScreenTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/map/MapScreenTest.kt
@@ -468,12 +468,8 @@ class MapScreenTest {
     advanceUntilIdle()
     mapViewModel.refreshReports()
 
-    val uiState = mapViewModel.uiState
+    val spiderifiedReport = mapViewModel.uiState.map { it.reports }.first { it.size == 19 }
 
-    uiState.map { it.reports }.first { it.isNotEmpty() }
-    advanceUntilIdle()
-
-    val spiderifiedReport = uiState.value.reports
     val groups = spiderifiedReport.groupBy { it.center }
 
     val group1 =


### PR DESCRIPTION
### Bug Fix
---
#### Summary
- Bug introduced by #417 in MapViewModel, changed the timing of the VM which introduced a failing test in MapTest.
- Add wait condition in spiderifyReportsTest to make sure the reports have been added to the repository and refreshed in the VM.
### Information for the team.
---
### Information for the reviewer.
---
#### How to test changes.
- Run the MapTest suite

