### PR TITLE
Bugfix/411

### DIFF
--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/office/ViewOfficeScreenTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/office/ViewOfficeScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.android.agrihealth.data.model.images.ImageViewModel
+import com.android.agrihealth.data.model.location.Location
 import com.android.agrihealth.data.model.office.Office
 import com.android.agrihealth.testutil.FakeImageRepository
 import com.android.agrihealth.testutil.FakeOfficeRepository
@@ -53,7 +54,7 @@ class ViewOfficeScreenTest {
         Office(
             id = "o1",
             name = "Agri Vet Clinic",
-            address = null,
+            address = Location(0.0, 0.0, "123 Farm Road, Countryside"),
             description = "Providing quality veterinary services for farm animals.",
             vets = listOf("vet1", "vet2"),
             ownerId = "owner1",
@@ -145,6 +146,16 @@ class ViewOfficeScreenTest {
         .onNodeWithTag(ViewOfficeScreenTestTags.DESCRIPTION_FIELD)
         .assertExists()
         .assertIsDisplayed()
+  }
+
+  @Test
+  fun addressField_showsWhenAddressExists() {
+    setBasicTestScreen()
+    composeTestRule
+        .onNodeWithTag(ViewOfficeScreenTestTags.ADDRESS_FIELD)
+        .assertExists()
+        .assertIsDisplayed()
+        .assertTextContains("123 Farm Road, Countryside")
   }
 
   @Test

--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/user/ViewUserScreenTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/ui/user/ViewUserScreenTest.kt
@@ -214,7 +214,7 @@ class ViewUserScreenTest {
             firstname = "No Inspiration",
             lastname = "Anymore",
             email = "mail@mail.com",
-            address = Location(latitude = 0.0, longitude = 0.0),
+            address = Location(latitude = 0.0, longitude = 0.0, "Location name"),
             linkedOffices = emptyList(),
             defaultOffice = null)
 
@@ -225,6 +225,7 @@ class ViewUserScreenTest {
         .onNodeWithTag(ViewUserScreenTestTags.ADDRESS_FIELD)
         .assertExists()
         .assertIsDisplayed()
+        .assertTextContains(farmer.address?.name ?: "")
   }
 
   @Test

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ViewOfficeScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ViewOfficeScreen.kt
@@ -139,9 +139,9 @@ private fun ViewOfficeContent(
             enabled = false,
             modifier = Modifier.fillMaxWidth().testTag(ViewOfficeScreenTestTags.NAME_FIELD))
 
-        office.address?.let {
+        office.address?.name?.let {
           OutlinedTextField(
-              value = "Not implemented yet",
+              value = it,
               onValueChange = {},
               label = { Text("Address") },
               readOnly = true,

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/user/ViewUserScreen.kt
@@ -149,9 +149,9 @@ private fun ViewUserContent(user: User, officeName: String?) {
           Spacer(Modifier.height(8.dp))
         }
 
-        user.address?.let {
+        user.address?.name?.let {
           OutlinedTextField(
-              value = "Not implemented yet",
+              value = it,
               onValueChange = {},
               label = { Text("Address") },
               readOnly = true,


### PR DESCRIPTION
### #411 Display address for ViewUser/ViewOfficeScreen
#### Summary
- This PR makes sure the address is displayed on ViewUserScreen or ViewOfficeScreen if the user or office has an address with a displayable name associated.
### Information for the team.
---
#### Solved issues. (optional)
- closes #411
### Information for the reviewer.
---
#### How to test changes.
- View the profile of a user with an address set and check that the address name is correctly displayed, then do the same with an office
