### PR TITLE
Fix save button clearing the picture bug

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/ui/office/ManageOfficeViewModel.kt
@@ -1,7 +1,6 @@
 package com.android.agrihealth.ui.office
 
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.agrihealth.data.model.images.ImageUIState
@@ -119,35 +118,17 @@ class ManageOfficeViewModel(
       val office = _uiState.value.office ?: return
       var uploadedPath = _uiState.value.uploadedImagePath ?: _uiState.value.office?.photoUrl
 
-      Log.d("ManageOfficeViewModel", "uploadedPath: $uploadedPath")
-
       when (_uiState.value.photoChange) {
         PhotoChange.UNCHANGED -> {
-          // do nothing — keep existing photoUrl
-          Log.d(
-              "ManageOfficeViewModel",
-              "omg i thought this is a small fix like one line seriously: ${_uiState.value.photoChange}")
-          val uri = _uiState.value.photoUri
-          var testUploadedPath = ""
-          if (uri != null) {
-            testUploadedPath = imageViewModel.uploadAndWait(uri)
-          }
-          Log.d("ManageOfficeViewModel", "can i go to sleep?!: $testUploadedPath")
+          // keep existing photoUrl
         }
         PhotoChange.UPDATED -> {
-          Log.d(
-              "ManageOfficeViewModel",
-              "omg i thought this is a small fix like one line seriously: ${_uiState.value.photoChange}")
-
           val uri = _uiState.value.photoUri
           if (uri != null) {
             uploadedPath = imageViewModel.uploadAndWait(uri)
           }
         }
         PhotoChange.REMOVED -> {
-          Log.d(
-              "ManageOfficeViewModel",
-              "omg i thought this is a small fix like one line seriously: ${_uiState.value.photoChange}")
           uploadedPath = null
         }
       }


### PR DESCRIPTION
### #419 Fix save button clearing the picture bug
---
#### Summary
- Fic the bug: on ManageOfficeScreen, not changing the profile picture and clicking the save button clears the profile picuture
### Information for the team.
---
#### Important Changes. (optional)

#### Solved issues. (optional)
- #419
### Information for the reviewer.
---
#### How to test changes.
- Login as a vet, go to ManageOfficeScreen, don't change the profile picture and just click "save changes" button. Go back to ProfileScreen. Go to the ManageOfficeScreen again. You should still have your profile picture.
#### Implementation details.
- At first I thought adding the navigation to go back the previous screen will fix this, but it didn't. I'll keep the no navigation for now. I added the PhotoChange enum (kinda like status of the ManageOfficeScreen) to change the behavior of the updateOffice() depend on if the user actually updaetd the picture or not.
#### Additional Notes.
- Tell me if you have an idea of how to write the uppdateOffice() more clean, although this is blocking other Pr so I have to do it quick if there is.
