### PR TITLE
Hotfix/Fix map navigation from overview

### DIFF
--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/MainActivity.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/MainActivity.kt
@@ -490,6 +490,11 @@ fun AgriHealthApp(
                   type = NavType.StringType
                   nullable = true
                   defaultValue = null
+                },
+                navArgument("alertId") {
+                  type = NavType.StringType
+                  nullable = true
+                  defaultValue = null
                 })) { backStackEntry ->
           val lat = backStackEntry.arguments?.getString("lat")?.toDoubleOrNull()
           val lng = backStackEntry.arguments?.getString("lng")?.toDoubleOrNull()


### PR DESCRIPTION
### #431 Fix map overview navigation
---
#### Summary
- Fixes map navigation not showing the bottom bar and filters when accessed from Overview
### Information for the reviewer.
---
#### How to test changes.
- Open the app, view map from overview, report, and alert, check that the first has a bottom bar, filters and no top bar, and the opposite for the other two
#### Implementation details.
- Seems like we forgot to properly handle nav arguments when implementing nav from alerts. Oops
