### PR TITLE
Add Firebase Storage rules and fix image upload tests

### DIFF
--- a/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/data/model/images/ImageRepositoryTest.kt
+++ b/AgriHealth-Alert-main/app/src/androidTest/java/com/android/agrihealth/data/model/images/ImageRepositoryTest.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.net.Uri
 import android.util.Log
 import com.android.agrihealth.data.model.firebase.emulators.FirebaseEmulatorsTest
+import com.google.firebase.auth.FirebaseAuth
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -14,6 +15,8 @@ import kotlin.math.sqrt
 import kotlin.random.Random
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -39,6 +42,12 @@ class ImageRepositoryTest : FirebaseEmulatorsTest() {
   @Before
   fun setup() {
     Dispatchers.setMain(StandardTestDispatcher())
+    runBlocking {
+      val auth = FirebaseAuth.getInstance()
+      if (auth.currentUser == null) {
+        auth.signInAnonymously().await()
+      }
+    }
   }
 
   @After

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageRepositoryFirebase.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageRepositoryFirebase.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import com.android.agrihealth.data.model.images.ImageRepository.Companion.toBitmap
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import com.google.firebase.storage.FirebaseStorage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -21,10 +23,7 @@ class ImageRepositoryFirebase : ImageRepository {
 
   override suspend fun uploadImage(bytes: ByteArray): Result<String> {
     return try {
-      val uid =
-          com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
-              ?: return Result.failure(IllegalStateException("Not signed in"))
-
+      val uid = Firebase.auth.uid
       val fileName = System.currentTimeMillis()
       val childPath = "users/$uid/placeholder/$fileName.jpg"
       val imageRef = storage.reference.child(childPath)

--- a/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageRepositoryFirebase.kt
+++ b/AgriHealth-Alert-main/app/src/main/java/com/android/agrihealth/data/model/images/ImageRepositoryFirebase.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import com.android.agrihealth.data.model.images.ImageRepository.Companion.toBitmap
-import com.android.agrihealth.ui.user.UserViewModel
 import com.google.firebase.storage.FirebaseStorage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -22,16 +21,17 @@ class ImageRepositoryFirebase : ImageRepository {
 
   override suspend fun uploadImage(bytes: ByteArray): Result<String> {
     return try {
-      val uid = UserViewModel().uiState.value.user.uid
+      val uid =
+          com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
+              ?: return Result.failure(IllegalStateException("Not signed in"))
+
       val fileName = System.currentTimeMillis()
-      val childPath = "$uid/$fileName.jpg"
+      val childPath = "users/$uid/placeholder/$fileName.jpg"
       val imageRef = storage.reference.child(childPath)
 
       imageRef.putBytes(bytes).await()
 
-      val fullPath = imageRef.path
-
-      Result.success(fullPath)
+      Result.success(childPath)
     } catch (e: Exception) {
       Result.failure(e)
     }

--- a/AgriHealth-Alert-main/firebase-rules/storage.rules
+++ b/AgriHealth-Alert-main/firebase-rules/storage.rules
@@ -30,12 +30,12 @@ service firebase.storage {
       return isSignedIn() && request.auth.uid == uid;
     }
 
-    function underMax(bytes) {
-      return request.resource.size < bytes;
+    function underMax10MB() {
+      return request.resource.size < 10 * 1024 * 1024;
     }
 
     match /users/{userId}/{allPaths=**} {
-      allow read: if isSignedIn() && (
+      allow read: if (
         userId == request.auth.uid
         ||
         (
@@ -53,32 +53,30 @@ service firebase.storage {
         )
       );
 
-      allow write: if isOwner(userId) && underMax(200 * 1024 * 1024);
+      allow write: if isOwner(userId) && underMax10MB();
     }
 
     match /offices/{officeId}/{allPaths=**} {
-      allow read: if isSignedIn() && (
+      allow read: if (
         (hasRole("Vet") && myUser().officeId == officeId)
         ||
         (hasRole("Farmer") && officeId in myUser().linkedOffices)
       );
 
-     allow write: if isSignedIn()
-        && hasRole("Vet")
+      allow write: if hasRole("Vet")
         && myUser().officeId == officeId
         && officeDoc(officeId).ownerId == request.auth.uid
-        && underMax(200 * 1024 * 1024);
+        && underMax10MB();
     }
 
     match /reports/{reportId}/{allPaths=**} {
-      allow read: if isSignedIn() && (
+      allow read: if (
         (hasRole("Vet") && reportDoc(reportId).officeId == myUser().officeId)
         ||
         (hasRole("Farmer") && reportDoc(reportId).farmerId == request.auth.uid)
       );
 
-     allow write: if isSignedIn()
-        && underMax(200 * 1024 * 1024)
+      allow write: if underMax10MB()
         && (
           (hasRole("Farmer") && reportDoc(reportId).farmerId == request.auth.uid)
           ||
@@ -86,8 +84,5 @@ service firebase.storage {
         );
     }
 
-    match /{allPaths=**} {
-      allow read, write: if false;
-    }
   }
 }

--- a/AgriHealth-Alert-main/firebase-rules/storage.rules
+++ b/AgriHealth-Alert-main/firebase-rules/storage.rules
@@ -53,7 +53,7 @@ service firebase.storage {
         )
       );
 
-      allow write: if isOwner(userId) && underMax(5 * 1024 * 1024);
+      allow write: if isOwner(userId) && underMax(200 * 1024 * 1024);
     }
 
     match /offices/{officeId}/{allPaths=**} {
@@ -67,7 +67,7 @@ service firebase.storage {
         && hasRole("Vet")
         && myUser().officeId == officeId
         && officeDoc(officeId).ownerId == request.auth.uid
-        && underMax(10 * 1024 * 1024);
+        && underMax(200 * 1024 * 1024);
     }
 
     match /reports/{reportId}/{allPaths=**} {
@@ -78,7 +78,7 @@ service firebase.storage {
       );
 
      allow write: if isSignedIn()
-        && underMax(10 * 1024 * 1024)
+        && underMax(200 * 1024 * 1024)
         && (
           (hasRole("Farmer") && reportDoc(reportId).farmerId == request.auth.uid)
           ||

--- a/AgriHealth-Alert-main/firebase-rules/storage.rules
+++ b/AgriHealth-Alert-main/firebase-rules/storage.rules
@@ -1,9 +1,93 @@
 rules_version = '2';
-
 service firebase.storage {
   match /b/{bucket}/o {
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function myUser() {
+      return firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data;
+    }
+
+    function userDoc(uid) {
+      return firestore.get(/databases/(default)/documents/users/$(uid)).data;
+    }
+
+    function officeDoc(officeId) {
+      return firestore.get(/databases/(default)/documents/offices/$(officeId)).data;
+    }
+
+    function reportDoc(reportId) {
+      return firestore.get(/databases/(default)/documents/reports/$(reportId)).data;
+    }
+
+    function hasRole(role) {
+      return isSignedIn() && myUser().role == role;
+    }
+
+    function isOwner(uid) {
+      return isSignedIn() && request.auth.uid == uid;
+    }
+
+    function underMax(bytes) {
+      return request.resource.size < bytes;
+    }
+
+    match /users/{userId}/{allPaths=**} {
+      allow read: if isSignedIn() && (
+        userId == request.auth.uid
+        ||
+        (
+          hasRole("Vet") && (
+            (userDoc(userId).role == "Vet" && userDoc(userId).officeId == myUser().officeId)
+            ||
+            (userDoc(userId).role == "Farmer" && myUser().officeId in userDoc(userId).linkedOffices)
+          )
+        )
+        ||
+        (
+          hasRole("Farmer")
+          && userDoc(userId).role == "Vet"
+          && userDoc(userId).officeId in myUser().linkedOffices
+        )
+      );
+
+      allow write: if isOwner(userId) && underMax(5 * 1024 * 1024);
+    }
+
+    match /offices/{officeId}/{allPaths=**} {
+      allow read: if isSignedIn() && (
+        (hasRole("Vet") && myUser().officeId == officeId)
+        ||
+        (hasRole("Farmer") && officeId in myUser().linkedOffices)
+      );
+
+     allow write: if isSignedIn()
+        && hasRole("Vet")
+        && myUser().officeId == officeId
+        && officeDoc(officeId).ownerId == request.auth.uid
+        && underMax(10 * 1024 * 1024);
+    }
+
+    match /reports/{reportId}/{allPaths=**} {
+      allow read: if isSignedIn() && (
+        (hasRole("Vet") && reportDoc(reportId).officeId == myUser().officeId)
+        ||
+        (hasRole("Farmer") && reportDoc(reportId).farmerId == request.auth.uid)
+      );
+
+     allow write: if isSignedIn()
+        && underMax(10 * 1024 * 1024)
+        && (
+          (hasRole("Farmer") && reportDoc(reportId).farmerId == request.auth.uid)
+          ||
+          (hasRole("Vet") && reportDoc(reportId).officeId == myUser().officeId)
+        );
+    }
+
     match /{allPaths=**} {
-      allow read, write: if true;
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
### #321 Add Firebase Storage rules + fix image uploads/tests (auth + paths)
---
#### Summary
- Add Firebase Storage security rules and align image upload paths with them.
- Fix image upload/download instrumentation tests by signing in a user (anonymous) and using FirebaseAuth UID.
- This improves security (deny-by-default + role-based access) and makes image upload tests reliable.

### Information for the team.
---
#### Important Changes. (optional)
- Storage is now protected by explicit rules: only users can write under users/{uid}/..., and access to offices/ and reports/ is role/relationship-based via Firestore docs.
- ImageRepositoryFirebase no longer relies on a ViewModel to get a UID; it uses FirebaseAuth (source of truth).

### Information for the reviewer.
---
#### How to test changes.
- Run ImageRepositoryTest. 
- No other tests, they all should pass.

#### Implementation details.
- Storage rules query Firestore (users/offices/reports) to enforce role-based access control and deny everything else by default.
- Repository builds paths under users/{uid}/... using FirebaseAuth.currentUser.uid (required by rules).

#### Additional Notes.
- Continues #428 . 